### PR TITLE
add json tags to payload envelope

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -102,7 +102,7 @@ func TestBroker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prefix := fmt.Sprintf(`{"CreatedAt":"%s","EventType":"Foo","Payload":`, now.Format(time.RFC3339Nano))
+	prefix := fmt.Sprintf(`{"created_at":"%s","event_type":"Foo","payload":`, now.Format(time.RFC3339Nano))
 	suffix := "}\n"
 	var expect string
 	for _, s := range []string{`{"color":"red","width":1}`, `{"color":"green","width":2}`, `{"color":"blue","width":4}`} {

--- a/formatter.go
+++ b/formatter.go
@@ -15,9 +15,9 @@ func (w *JSONFormatter) Process(ctx context.Context, e *Event) (*Event, error) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	err := enc.Encode(struct {
-		CreatedAt time.Time
-		EventType
-		Payload interface{}
+		CreatedAt time.Time `json:"created_at"`
+		EventType `json:"event_type"`
+		Payload   interface{} `json:"payload"`
 	}{
 		e.CreatedAt,
 		e.Type,


### PR DESCRIPTION
I think most of our tools will expect snake_cased keys, vault audit logs currently are set up this way as well as other json sinks across our products