### PR TITLE
mark complete when a node filters an event without error

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -182,18 +182,3 @@ func (b *Broker) SetSuccessThreshold(t EventType, successThreshold int) error {
 	g.successThreshold = successThreshold
 	return nil
 }
-
-// SetAllowFilterCompletion sets whether or not a node filtering an event
-// counts towards the completion status of that node.
-func (b *Broker) SetAllowFilterCompletion(t EventType, allow bool) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	g, ok := b.graphs[t]
-	if !ok {
-		g = &graph{roots: make(map[PipelineID]*linkedNode)}
-		b.graphs[t] = g
-	}
-
-	g.allowFilterCompletion = allow
-}

--- a/broker_test.go
+++ b/broker_test.go
@@ -68,9 +68,6 @@ func TestBroker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Allow filtering of events to count towards completion of graph
-	broker.SetAllowFilterCompletion(et, true)
-
 	// Process some Events
 	payloads := []interface{}{
 		map[string]interface{}{

--- a/graph.go
+++ b/graph.go
@@ -17,10 +17,6 @@ type graph struct {
 	// successThreshold specifies how many sinks must store an event for Process
 	// to not return an error.
 	successThreshold int
-
-	// allowFilterCompletion specifies if a filter node filtering an event
-	// can count as a status completion
-	allowFilterCompletion bool
 }
 
 // Process the Event by routing it through all of the graph's nodes,
@@ -68,11 +64,12 @@ func (g *graph) doProcess(ctx context.Context, node *linkedNode, e *Event, statu
 		return
 	}
 	// If the Event is nil, it has been filtered out and we are done.
-	if g.allowFilterCompletion && e == nil {
+	if e == nil {
 		select {
 		case <-ctx.Done():
 		case statusChan <- Status{complete: []NodeID{node.nodeID}}:
 		}
+		return
 	}
 
 	// Process any child nodes.  This is depth-first.


### PR DESCRIPTION
Sends a complete status when a node filters an event (returning a nil event with no error)