### PR TITLE
Encrypt Filter: add classifications, filter operations and tag functions

### DIFF
--- a/filters/encrypt/classification.go
+++ b/filters/encrypt/classification.go
@@ -1,7 +1,6 @@
 package encrypt
 
 const (
-
 	// RedactedData is the value that replaces redacted data (secrets)
 	RedactedData = "<REDACTED>"
 

--- a/filters/encrypt/classification.go
+++ b/filters/encrypt/classification.go
@@ -1,0 +1,33 @@
+package encrypt
+
+const (
+
+	// RedactedData is the value that replaces redacted data (secrets)
+	RedactedData = "<REDACTED>"
+
+	// DataClassificationTagName is the tag name for classifying data into
+	// DataClassification's
+	DataClassificationTagName = "classified"
+)
+
+// DataClassification defines a type for classification of data into categories
+// like: public, sensitive, secret, etc.  DataClassifications are used with as
+// values for tags using DataClassificationTagName to declare a type of
+// classification.
+type DataClassification string
+
+const (
+	UnknownClassification DataClassification = "unknown"
+
+	// PublicClassification declares a field as public data.  No filter
+	// operations are ever performed on public data.
+	PublicClassification DataClassification = "public"
+
+	// SensitiveClassification declares a field as sensitive data.  By default,
+	// sensitive data is encrypted unless the tag includes an overriding FilterOperation.
+	SensitiveClassification DataClassification = "sensitive"
+
+	// SecretClassification declares a field as secret data.  By default,
+	// secret data is redacted unless the tag includes an overriding FilterOperation.
+	SecretClassification DataClassification = "secret"
+)

--- a/filters/encrypt/filter_operation.go
+++ b/filters/encrypt/filter_operation.go
@@ -5,7 +5,6 @@ import "strings"
 // FilterOperation defines a type for filtering operations like: redact,
 // encrypt, hmac-sha256, etc.  Used in combination with a DataClassification, it
 // allows developers to override the default filter operations on tag fields.
-
 type FilterOperation string
 
 const (

--- a/filters/encrypt/filter_operation.go
+++ b/filters/encrypt/filter_operation.go
@@ -1,0 +1,33 @@
+package encrypt
+
+import "strings"
+
+// FilterOperation defines a type for filtering operations like: redact,
+// encrypt, hmac-sha256, etc.  Used in combination with a DataClassification, it
+// allows developers to override the default filter operations on tag fields.
+
+type FilterOperation string
+
+const (
+	NoOperation         FilterOperation = ""
+	UnknownOperation    FilterOperation = "unknown"
+	RedactOperation     FilterOperation = "redact"
+	EncryptOperation    FilterOperation = "encrypt"
+	HmacSha256Operation FilterOperation = "hmac-sha256"
+)
+
+func convertToOperation(seg string) FilterOperation {
+	seg = strings.ToLower(seg)
+	switch FilterOperation(seg) {
+	case NoOperation:
+		return NoOperation
+	case HmacSha256Operation:
+		return HmacSha256Operation
+	case EncryptOperation:
+		return EncryptOperation
+	case RedactOperation:
+		return RedactOperation
+	default:
+		return UnknownOperation
+	}
+}

--- a/filters/encrypt/filter_operation_test.go
+++ b/filters/encrypt/filter_operation_test.go
@@ -1,0 +1,54 @@
+package encrypt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_convertToOperation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		seg  string
+		want FilterOperation
+	}{
+		{
+			name: "NoOperation",
+			seg:  "",
+			want: NoOperation,
+		},
+		{
+			name: "UnknownOperation",
+			seg:  "unknown",
+			want: UnknownOperation,
+		},
+		{
+			name: "RedactOperation",
+			seg:  "redact",
+			want: RedactOperation,
+		},
+		{
+			name: "EncryptOperation",
+			seg:  "encrypt",
+			want: EncryptOperation,
+		},
+		{
+			name: "HmacSha256Operation",
+			seg:  "hmac-sha256",
+			want: HmacSha256Operation,
+		},
+		{
+			name: "default-UnknownOperation",
+			seg:  "doesn't matter what you put here",
+			want: UnknownOperation,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := convertToOperation(tt.seg)
+			assert.Equal(tt.want, got)
+		})
+	}
+}

--- a/filters/encrypt/options.go
+++ b/filters/encrypt/options.go
@@ -1,0 +1,30 @@
+package encrypt
+
+// getOpts - iterate the inbound Options and return a struct.
+func getOpts(opt ...Option) options {
+	opts := getDefaultOptions()
+	for _, o := range opt {
+		if o != nil {
+			o(&opts)
+		}
+	}
+	return opts
+}
+
+// Option - how Options are passed as arguments.
+type Option func(*options)
+
+// options = how options are represented
+type options struct {
+	withFilterOperations map[DataClassification]FilterOperation
+}
+
+func getDefaultOptions() options {
+	return options{}
+}
+
+func withFilterOperations(ops map[DataClassification]FilterOperation) Option {
+	return func(o *options) {
+		o.withFilterOperations = ops
+	}
+}

--- a/filters/encrypt/options_test.go
+++ b/filters/encrypt/options_test.go
@@ -1,0 +1,24 @@
+package encrypt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_getOpts provides unit tests for getOpts and all the options
+func Test_getOpts(t *testing.T) {
+	t.Parallel()
+	t.Run("withFilterOperations", func(t *testing.T) {
+		assert := assert.New(t)
+		filters := map[DataClassification]FilterOperation{
+			UnknownClassification: RedactOperation,
+			PublicClassification:  NoOperation,
+			SecretClassification:  EncryptOperation,
+		}
+		opts := getOpts(withFilterOperations(filters))
+		testOpts := getDefaultOptions()
+		testOpts.withFilterOperations = filters
+		assert.Equal(opts, testOpts)
+	})
+}

--- a/filters/encrypt/tag.go
+++ b/filters/encrypt/tag.go
@@ -22,6 +22,12 @@ func getClassificationFromTag(f reflect.StructTag, opt ...Option) *tagInfo {
 	return getClassificationFromTagString(t, opt...)
 }
 
+// getClassificationFromTagString takes a tag (as a string) and supports the
+// WithFilterOperations option. It will parse the tag string and determine its
+// DataClassification and Operation which will be returned in a tagInfo pointer.
+//
+// The default classification == UnknownOperation and the default operation ==
+// NoOperation. The classification and operation are delimited by a comma ","
 func getClassificationFromTagString(tag string, opt ...Option) *tagInfo {
 	const op = "node.getClassificationFromTagString"
 	segs := strings.Split(tag, ",") // will always return at least 1 segment

--- a/filters/encrypt/tag.go
+++ b/filters/encrypt/tag.go
@@ -1,0 +1,81 @@
+package encrypt
+
+import (
+	"reflect"
+	"strings"
+)
+
+type tagInfo struct {
+	Classification DataClassification
+	Operation      FilterOperation
+}
+
+func getClassificationFromTag(f reflect.StructTag, opt ...Option) *tagInfo {
+	t, ok := f.Lookup(DataClassificationTagName)
+
+	if !ok {
+		return &tagInfo{
+			Classification: UnknownClassification,
+			Operation:      UnknownOperation,
+		}
+	}
+	return getClassificationFromTagString(t, opt...)
+}
+
+func getClassificationFromTagString(tag string, opt ...Option) *tagInfo {
+	const op = "node.getClassificationFromTagString"
+	segs := strings.Split(tag, ",") // will always return at least 1 segment
+
+	var operation FilterOperation
+	switch len(segs) {
+	case 0, 1:
+		operation = NoOperation
+	default:
+		operation = convertToOperation(segs[1])
+	}
+	if operation == UnknownOperation {
+		// setting a reasonable default is better than returning an ambiguous error
+		operation = NoOperation
+	}
+
+	classification := DataClassification(segs[0])
+	opts := getOpts(opt...)
+	if operationOverride, ok := opts.withFilterOperations[classification]; ok {
+		return &tagInfo{
+			Classification: classification,
+			Operation:      operationOverride,
+		}
+	}
+
+	switch classification {
+	case PublicClassification:
+		return &tagInfo{
+			Classification: PublicClassification,
+			Operation:      NoOperation,
+		}
+	case SensitiveClassification:
+		if operation == NoOperation {
+			// set a default
+			operation = EncryptOperation
+		}
+		return &tagInfo{
+			Classification: SensitiveClassification,
+			Operation:      operation,
+		}
+	case SecretClassification:
+		if operation == NoOperation {
+			// set a default
+			operation = RedactOperation
+		}
+		return &tagInfo{
+			Classification: SecretClassification,
+			Operation:      operation,
+		}
+	default:
+		// returning a reasonable default is better than returning an ambiguous error
+		return &tagInfo{
+			Classification: UnknownClassification,
+			Operation:      UnknownOperation,
+		}
+	}
+}

--- a/filters/encrypt/tag_test.go
+++ b/filters/encrypt/tag_test.go
@@ -124,7 +124,6 @@ func Test_getClassificationFromTagString(t *testing.T) {
 				Operation:      EncryptOperation,
 			},
 		},
-		// -------------
 		{
 			name: "secret-with-no-operation",
 			tag:  string(SecretClassification),

--- a/filters/encrypt/tag_test.go
+++ b/filters/encrypt/tag_test.go
@@ -1,0 +1,131 @@
+package encrypt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getClassificationFromTagString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		tag  string
+		opt  []Option
+		want *tagInfo
+	}{
+		{
+			name: "no-tag",
+			want: &tagInfo{
+				Classification: UnknownClassification,
+				Operation:      UnknownOperation,
+			},
+		},
+		{
+			name: "public-with-no-operation",
+			tag:  string(PublicClassification),
+			want: &tagInfo{
+				Classification: PublicClassification,
+				Operation:      NoOperation,
+			},
+		},
+		{
+			name: "public-with-operation",
+			tag:  fmt.Sprintf("%s,%s", string(PublicClassification), RedactOperation),
+			want: &tagInfo{
+				Classification: PublicClassification,
+				Operation:      NoOperation,
+			},
+		},
+		{
+			name: "public-with-operation-override",
+			tag:  fmt.Sprintf("%s,%s", string(PublicClassification), EncryptOperation),
+			opt: []Option{withFilterOperations(map[DataClassification]FilterOperation{
+				PublicClassification: RedactOperation,
+			})},
+			want: &tagInfo{
+				Classification: PublicClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "sensitive-with-no-operation",
+			tag:  string(SensitiveClassification),
+			want: &tagInfo{
+				Classification: SensitiveClassification,
+				Operation:      EncryptOperation,
+			},
+		},
+		{
+			name: "sensitive-with-operation",
+			tag:  fmt.Sprintf("%s,%s", string(SensitiveClassification), RedactOperation),
+			want: &tagInfo{
+				Classification: SensitiveClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "sensitive-with-operation-override",
+			tag:  fmt.Sprintf("%s,%s", string(SensitiveClassification), EncryptOperation),
+			opt: []Option{withFilterOperations(map[DataClassification]FilterOperation{
+				SensitiveClassification: RedactOperation,
+			})},
+			want: &tagInfo{
+				Classification: SensitiveClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "sensitive-with-unknown-operation",
+			tag:  fmt.Sprintf("%s,%s", string(SensitiveClassification), UnknownOperation),
+			want: &tagInfo{
+				Classification: SensitiveClassification,
+				Operation:      EncryptOperation,
+			},
+		},
+		// -------------
+		{
+			name: "secret-with-no-operation",
+			tag:  string(SecretClassification),
+			want: &tagInfo{
+				Classification: SecretClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "secret-with-operation",
+			tag:  fmt.Sprintf("%s,%s", string(SecretClassification), RedactOperation),
+			want: &tagInfo{
+				Classification: SecretClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "secret-with-operation-override",
+			tag:  fmt.Sprintf("%s,%s", string(SecretClassification), EncryptOperation),
+			opt: []Option{withFilterOperations(map[DataClassification]FilterOperation{
+				SecretClassification: RedactOperation,
+			})},
+			want: &tagInfo{
+				Classification: SecretClassification,
+				Operation:      RedactOperation,
+			},
+		},
+		{
+			name: "secret-with-unknown-operation",
+			tag:  fmt.Sprintf("%s,%s", string(SecretClassification), UnknownOperation),
+			want: &tagInfo{
+				Classification: SecretClassification,
+				Operation:      RedactOperation,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := getClassificationFromTagString(tt.tag, tt.opt...)
+			assert.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This is the start of implementing the new node described in ENG-034

`jimlambrt-encrypt-filter-feature` will be a long-lived branch for all the PRs related to this on-going implementation.  Once all the PRs required to fully implement the feature have been reviewed and merged into this long-lived branch it will be merged into main and the new feature will be generally available. 

There is a work in progress (wip) branch that contains much of the completed feature and is the source for these on-going implementation PRs.  This wip branch (`jimlambrt-encrypt-feature-wip`) is subject to ongoing changes but it reviewers should feel free to reference it for more contextual information about any of these implementation PRs.

thanks, 
j.