### PR TITLE
add newline to test output written to stdout for Writer sink.

### DIFF
--- a/sinks/writer/writer_test.go
+++ b/sinks/writer/writer_test.go
@@ -15,7 +15,7 @@ func TestWriterSink_Process(t *testing.T) {
 	ctx := context.Background()
 
 	event := &eventlogger.Event{
-		Formatted: map[string][]byte{eventlogger.JSONFormat: []byte("first")},
+		Formatted: map[string][]byte{eventlogger.JSONFormat: []byte("first\n")},
 		Payload:   "First entry",
 	}
 
@@ -30,7 +30,7 @@ func TestWriterSink_Process(t *testing.T) {
 			name:   "simple",
 			writer: &bytes.Buffer{},
 			e:      event,
-			want:   "first",
+			want:   "first\n",
 		},
 		{
 			name:    "nil-writer",


### PR DESCRIPTION
Currently `gotestsum` was incorrectly stated that a few unit tests failed because they wrote to stdout without a newline.  This is sort of a "known" problem highlighted in this issue: https://github.com/golang/go/issues/38063

This PR simply adds a newline to the output to stop these false positives.  