### PR TITLE
Don't set permissions on pre-existing parent dir

### DIFF
--- a/file_sink.go
+++ b/file_sink.go
@@ -172,9 +172,10 @@ func (fs *FileSink) open() error {
 	}
 
 	// Change the file mode in case the log file already existed. We special
-	// case /dev/null since we can't chmod it and bypass if the mode is zero
+	// case a few paths since we can't chmod them, and bypass if the mode is zero
 	switch newfilePath {
 	case "/dev/null":
+	case "/dev/stderr":
 	case "/dev/stdout":
 	default:
 		if fs.Mode != 0 {

--- a/file_sink.go
+++ b/file_sink.go
@@ -173,11 +173,12 @@ func (fs *FileSink) open() error {
 
 	// Change the file mode in case the log file already existed. We special
 	// case /dev/null since we can't chmod it and bypass if the mode is zero
-	switch fs.Path {
+	switch newfilePath {
 	case "/dev/null":
+	case "/dev/stdout":
 	default:
 		if fs.Mode != 0 {
-			err = os.Chmod(fs.Path, fs.Mode)
+			err = os.Chmod(newfilePath, fs.Mode)
 			if err != nil {
 				return err
 			}

--- a/file_sink_test.go
+++ b/file_sink_test.go
@@ -324,6 +324,6 @@ func TestFileSink_DirMode(t *testing.T) {
 	// Ensure the parent directory's permissions remain unchanged
 	actualDirMode := dirInfo.Mode()
 	if actualDirMode.Perm() != parentDirMode.Perm() {
-		t.Errorf("Expected file mode %q, got %s", parentDirMode.Perm(), actualDirMode.Perm())
+		t.Errorf("Expected file mode %q, got %q", parentDirMode.Perm(), actualDirMode.Perm())
 	}
 }


### PR DESCRIPTION
When a non-default file sink mode is configured, the parent directory's permissions are also modified to match the configured mode. If the desired mode does not include execute permissions, the permission change effectively removes the ability for a non-root user to enter into the directory.

This change makes it so that only the created file's permissions are modified. The parent directory's permissions are unchanged if the directory already exists.