### PR TITLE
Add initial implementation of `classtaglint`

### DIFF
--- a/cmd/classtaglint/Makefile
+++ b/cmd/classtaglint/Makefile
@@ -1,0 +1,8 @@
+install:
+	@echo "🛠  Building classtaglint"
+	@go build -o classtaglint .
+	@echo "📦 Moved classtaglint to /usr/local/bin"
+	@mv classtaglint /usr/local/bin
+
+test:
+	@go test -timeout 30s github.com/hashicorp/eventlogger/cmd/classtaglint/classtagcheck -v

--- a/cmd/classtaglint/README.md
+++ b/cmd/classtaglint/README.md
@@ -1,0 +1,61 @@
+# `classtaglint` 
+
+The `classtaglint` command implements a [`go/analysis`](https://pkg.go.dev/golang.org/x/tools/go/analysis)
+based linter to analyze usage of the [`github.com/hashicorp/eventlogger/filters/encrypt`](https://pkg.go.dev/github.com/hashicorp/eventlogger/filters/encrypt)'s
+`class` struct tags.
+
+## Usage
+
+```console
+$ classtaglint
+classtaglint: analyze usage of class struct tags
+
+Usage: classtaglint [-flag] [package]
+
+
+Flags:
+  -V    print version and exit
+  -all
+        no effect (deprecated)
+  -c int
+        display offending line with this many lines of context (default -1)
+  -cpuprofile string
+        write CPU profile to this file
+  -debug string
+        debug flags, any subset of "fpstv"
+  -fix
+        apply all suggested fixes
+  -flags
+        print analyzer flags in JSON
+  -json
+        emit JSON output
+  -memprofile string
+        write memory profile to this file
+  -source
+        no effect (deprecated)
+  -tags string
+        no effect (deprecated)
+  -trace string
+        write trace log to this file
+  -v    no effect (deprecated)
+```
+
+```
+$ cd classtagcheck/testdata/src/a/
+classtaglint .
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:14:35: invalid data classification: "sensitve"
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:15:35: invalid filter operation: "secrt"
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:16:35: invalid data classification: "senitive"
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:17:35: found 2 data classifications for single field
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:18:35: invalid data classification for non-filterable type
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:19:35: filter operations invalid on public data classifications
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:20:35: filter operations invalid on public data classifications
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:20:35: invalid filter operation: "redct"
+/full/path/go-eventlogger/cmd/classtaglint/classtagcheck/testdata/src/a/main.go:21:35: too many classification options given: 3
+$ classtaglint -json .
+...
+$ go vet -vettool=$(which classtaglint)
+...
+$ $ go vet -vettool=$(which classtaglint) -json 
+```
+

--- a/cmd/classtaglint/classtagcheck/check.go
+++ b/cmd/classtaglint/classtagcheck/check.go
@@ -1,0 +1,143 @@
+package classtagcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/eventlogger/filters/encrypt"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:             "classtaglint",
+	Doc:              "analyze usage of class struct tags",
+	Run:              run,
+	Requires:         []*analysis.Analyzer{inspect.Analyzer},
+	RunDespiteErrors: true,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		structType := n.(*ast.StructType)
+
+		for _, field := range structType.Fields.List {
+			checkStructField(pass, field)
+		}
+	})
+
+	return nil, nil
+}
+
+func checkStructField(pass *analysis.Pass, field *ast.Field) error {
+	// ensure the field has a string tag
+	tag := field.Tag
+
+	if tag == nil || tag.Kind != token.STRING {
+		return nil
+	}
+
+	// chop beginning and ending "`"
+	tagValue := field.Tag.Value
+	tagValue = strings.TrimPrefix(tagValue, "`")
+	tagValue = strings.TrimSuffix(tagValue, "`")
+
+	// look for multiple class tags
+	var foundClassDeclared int
+
+	// iterate over tag content
+	tagFields := strings.Fields(tagValue)
+	for _, tf := range tagFields {
+		if strings.HasPrefix(tf, "class:") {
+			foundClassDeclared++
+
+			classOptionsValue, err := strconv.Unquote(strings.TrimPrefix(tf, "class:"))
+			if err != nil {
+				return fmt.Errorf("failed to parse class tag value while unqoute options: %w", err)
+			}
+			classOptions := strings.Split(classOptionsValue, ",")
+
+			var (
+				classification string
+				operation      string
+			)
+
+			if len(classOptions) >= 1 {
+				classification = classOptions[0]
+			}
+
+			if len(classOptions) >= 2 {
+				operation = classOptions[1]
+			}
+
+			if len(classOptions) >= 3 {
+				pass.Reportf(field.Tag.Pos(), "too many classification options given: %d", len(classOptions))
+			}
+
+			switch encrypt.DataClassification(classification) {
+			case encrypt.UnknownClassification:
+				if operation != "" {
+					pass.Reportf(field.Tag.Pos(), "filter operations invalid on unknown data classifications")
+				}
+			case encrypt.PublicClassification:
+				if operation != "" {
+					pass.Reportf(field.Tag.Pos(), "filter operations invalid on public data classifications")
+				}
+			case encrypt.SecretClassification:
+				checkStructFieldTypeFilterable(pass, field)
+			case encrypt.SensitiveClassification:
+				checkStructFieldTypeFilterable(pass, field)
+			default:
+				pass.Reportf(field.Tag.Pos(), "invalid data classification: %q", classification)
+			}
+
+			if operation != "" {
+				switch encrypt.FilterOperation(operation) {
+				case encrypt.RedactOperation:
+					// TODO
+				case encrypt.EncryptOperation:
+					// TODO
+				case encrypt.HmacSha256Operation:
+					// TODO
+				case encrypt.NoOperation:
+					// TODO
+				default:
+					pass.Reportf(field.Tag.Pos(), "invalid filter operation: %q", operation)
+				}
+			}
+
+		}
+	}
+
+	if foundClassDeclared > 1 {
+		pass.Reportf(field.Tag.Pos(), "found %d data classifications for single field", foundClassDeclared)
+	}
+
+	return nil
+}
+
+func checkStructFieldTypeFilterable(pass *analysis.Pass, field *ast.Field) {
+	fieldType := pass.TypesInfo.TypeOf(field.Type)
+	if fieldType == nil {
+		return
+	}
+
+	switch fieldType.String() {
+	case "string":
+	case "[]string":
+	case "[]byte":
+	case "[][]byte":
+	default:
+		pass.Reportf(field.Tag.Pos(), "invalid data classification for non-filterable type")
+	}
+}

--- a/cmd/classtaglint/classtagcheck/check_test.go
+++ b/cmd/classtaglint/classtagcheck/check_test.go
@@ -1,0 +1,17 @@
+package classtagcheck
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+var testdata string
+
+func init() {
+	testdata = analysistest.TestData()
+}
+
+func TestExample(t *testing.T) {
+	analysistest.Run(t, testdata, Analyzer, "example")
+}

--- a/cmd/classtaglint/classtagcheck/testdata/src/example/main.go
+++ b/cmd/classtaglint/classtagcheck/testdata/src/example/main.go
@@ -1,0 +1,24 @@
+package example
+
+import (
+	"time"
+)
+
+type example struct {
+	ExampleX               string    `json:"name,omitempty" xml:"name"`
+	ExampleY               string    `json:" xml:"name"`
+	ExampleZ               string    `""`
+	ExampleZz              string    ``
+	PublicId               string    `class:"public"`
+	SensitiveUserName      string    `class:"sensitive"`
+	SensitiveUserNameOops1 string    `class:"sensitve"`                    // want "invalid data classification: \"sensitve\""
+	SensitiveUserNameOops2 string    `class:"sensitive,secrt"`             // want "invalid filter operation: \"secrt\""
+	SensitiveBad           string    `class:"senitive"`                    // want "invalid data classification: \"senitive\""
+	SensitiveDouble        string    `class:"sensitive" class:"sensitive"` // want "found 2 data classifications for single field"
+	SensitiveNonFilterable time.Time `class:"sensitive"`                   // want "invalid data classification for non-filterable type"
+	NotFiltered            string    `class:"public,redact"`               // want "filter operations invalid on public data classifications"
+	NotFilteredEither      string    `class:"public,redct"`                // want "filter operations invalid on public data classifications" "invalid filter operation: \"redct\""
+	More                   string    `class:"sensitive,redact,more"`       // want "too many classification options given: 3"
+	NonFilterable          time.Time `class:"public"`
+	LoginTimestamp         time.Time
+}

--- a/cmd/classtaglint/main.go
+++ b/cmd/classtaglint/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/hashicorp/eventlogger/cmd/classtaglint/classtagcheck"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(classtagcheck.Analyzer)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/goleak v1.0.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
+	golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c // indirect
 	google.golang.org/protobuf v1.26.0
 	mvdan.cc/gofumpt v0.1.1
 )


### PR DESCRIPTION
Following up on discussion from ENG-034 and @jimlambrt's work in https://github.com/hashicorp/go-eventlogger/pull/46, this PR adds the initial implementation of the `classtaglint` linter for analyzing usage of `class` struct tags.