### PR TITLE
feat (encrypt): Setting filters to no operation.

### DIFF
--- a/filters/encrypt/filter_test.go
+++ b/filters/encrypt/filter_test.go
@@ -254,7 +254,7 @@ func TestFilter_filterValue(t *testing.T) {
 			name:            "unknown-filter-operation",
 			ef:              testFilter,
 			fv:              reflect.ValueOf(&testStr).Elem(),
-			classification:  &tagInfo{Classification: SecretClassification, Operation: NoOperation},
+			classification:  &tagInfo{Classification: SecretClassification, Operation: "not-a-valid-operation"},
 			wantErrIs:       ErrInvalidParameter,
 			wantErrContains: "unknown filter operation",
 		},
@@ -279,6 +279,13 @@ func TestFilter_filterValue(t *testing.T) {
 			fv:             reflect.ValueOf(&testStr),
 			classification: &tagInfo{Classification: SecretClassification, Operation: HmacSha256Operation},
 			wantValue:      TestHmacSha256(t, []byte("fido"), wrapper, []byte("salt"), []byte("info")),
+		},
+		{
+			name:           "success-no-operation",
+			ef:             testFilter,
+			fv:             reflect.ValueOf(&testStr).Elem(),
+			classification: &tagInfo{Classification: SecretClassification, Operation: NoOperation},
+			wantValue:      testStr,
 		},
 		{
 			name:           "success-public",

--- a/filters/encrypt/filter_test_pkg_test.go
+++ b/filters/encrypt/filter_test_pkg_test.go
@@ -135,6 +135,34 @@ func TestFilter_Process(t *testing.T) {
 		wantErrContains string
 	}{
 		{
+			name: "all-operations-are-no-op",
+			filter: &encrypt.Filter{
+				FilterOperationOverrides: func() map[encrypt.DataClassification]encrypt.FilterOperation {
+					ops := encrypt.DefaultFilterOperations()
+					for k := range ops {
+						ops[k] = encrypt.NoOperation
+					}
+					return ops
+				}(),
+			},
+			// this payload would normally raise an error because it needs
+			// redacting and the string is not settable... but since we're
+			// overriding all the filter operations to be NoOperation, it will
+			// succeed and it's a simple way to test if the no-op short
+			// circuiting is working when all the filter operations for a node
+			// are set to NoOperation
+			testEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload:   testString,
+			},
+			wantEvent: &eventlogger.Event{
+				Type:      "test",
+				CreatedAt: now,
+				Payload:   testString,
+			},
+		},
+		{
 			name:   "simple",
 			filter: testEncryptingFilter,
 			testEvent: &eventlogger.Event{


### PR DESCRIPTION
Add support to set a data classification's filter operation to
encrypt.NoOperation which was a use-case that hadn't been supported.

Also, if all filter operations == encrypt.NoOperation, then short
circuit the processing of the event and return the original event.
This will save a ton of unnecessary processing when no filtering is
required.