### PR TITLE
do not append timestamp to current log file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...

--- a/file_sink_test.go
+++ b/file_sink_test.go
@@ -142,8 +142,24 @@ func TestFileSink_TimeRotate(t *testing.T) {
 	}
 
 	want := 2
-	if got, _ := ioutil.ReadDir(tmpDir); len(got) != want {
+	got, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Error listing log directory: %v", err)
+	}
+	if len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
+	}
+	found := false
+	names := []string{}
+	for _, entry := range got {
+		names = append(names, entry.Name())
+		if entry.Name() == fs.FileName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Did not find expected file %q -- found: %v", fs.FileName, names)
 	}
 }
 
@@ -183,8 +199,24 @@ func TestFileSink_ByteRotate(t *testing.T) {
 	}
 
 	want := 2
-	if got, _ := ioutil.ReadDir(tmpDir); len(got) != want {
+	got, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Error listing log directory: %v", err)
+	}
+	if len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
+	}
+	found := false
+	names := []string{}
+	for _, entry := range got {
+		names = append(names, entry.Name())
+		if entry.Name() == fs.FileName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Did not find expected file %q -- found: %v", fs.FileName, names)
 	}
 }
 


### PR DESCRIPTION
This patch updates the file_sink to *not* append the timestamp on the current log file. The timestamp is only appended when the file is rotated.

This matches the behavior:

- Implemented in Nomad v1.1.4 with hashicorp/nomad#11070
- Requested in hashicorp/nomad#11061
- Referenced in Consul's documentation: https://www.consul.io/docs/enterprise/audit-logging

> The following example configures a destination called "My Sink" which
> stores audit events at the file `/tmp/audit.json`.

Nomad's documentation is a little vague but implies the prior behavior of always appending a timestamp.

While this is a *backward incompatible change* I think it's worth it for usability and matching Consul's documentation. Nomad's documentation can be fixed and a notice placed in the Upgrade Guide.

In a bid to try to win your support I labeled this PR a bug despite the tests and comments being very clear the old behavior (always append a timestamp) *was* intentional.