### PR TITLE
Events: filter map fields which are not tagged.

### DIFF
--- a/filters/encrypt/README.md
+++ b/filters/encrypt/README.md
@@ -25,6 +25,9 @@ event payload, when they are tagged with a `class` tag:
 * `wrapperspb.StringValue`
 * `wrapperspb.BytesValue`
 
+Note: tagging a map has no affect on it's filtering.  Please see `Taggable
+interface` for information about how to filter maps.
+
 The following DataClassifications are supported:
 * PublicClassification
 * SensitiveClassification
@@ -44,6 +47,16 @@ implementing a single function `Taggable` interface, which returns a
 `[]PointerTag` for fields that must be filtered.  You may have payloads and/or
 payload fields which implement the `Taggable` interface and also contain fields
 that are tagged with the `class` tag.
+
+## Important: 
+In general, the package defaults assume that unclassified data (including map
+fields) are secrets and filters them appropriately.  This means that:
+- When a map doesn't implement `Taggable` all of it's fields will be filtered as
+  secret data.
+- If a map's `Tags(...)` function doesn't return a PointerTag for a field, that
+  field will be filtered as secret data.
+
+
 ```go
 // Taggable defines an interface for taggable maps
 type Taggable interface {

--- a/filters/encrypt/filter.go
+++ b/filters/encrypt/filter.go
@@ -412,7 +412,8 @@ func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverride
 		}
 		rv := reflect.Indirect(reflect.ValueOf(value))
 		info := getClassificationFromTagString(fmt.Sprintf("%s,%s", pt.Classification, pt.Filter), withFilterOperations(filterOverrides))
-		if err = ef.filterValue(ctx, rv, info, withPointer(t, pt.Pointer)); err != nil {
+		opt = append(opt, withPointer(t, pt.Pointer))
+		if err = ef.filterValue(ctx, rv, info, opt...); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}
 		segs := strings.Split(pt.Pointer, "/")
@@ -492,7 +493,7 @@ func (ef *Filter) filterSlice(ctx context.Context, classificationTag *tagInfo, s
 	}
 
 	for i := 0; i < slice.Len(); i++ {
-		if err := ef.filterValue(ctx, slice.Index(i), classificationTag); err != nil {
+		if err := ef.filterValue(ctx, slice.Index(i), classificationTag, opt...); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}
 	}

--- a/filters/encrypt/filter.go
+++ b/filters/encrypt/filter.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/hashicorp/eventlogger"
@@ -397,7 +396,7 @@ func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverride
 	if err != nil {
 		return fmt.Errorf("%s: unable to get tags from taggable interface: %w", op, err)
 	}
-	tracked, err := newTrackedMaps()
+	trackedMaps, err := newTrackedMaps()
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
@@ -416,49 +415,12 @@ func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverride
 		if err = ef.filterValue(ctx, rv, info, opt...); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}
-		segs := strings.Split(pt.Pointer, "/")
-		switch {
-		case len(segs) == 2:
-			ptr := reflect.ValueOf(t).Pointer()
-			if _, ok := tracked[ptr]; !ok {
-				v := reflect.ValueOf(t)
-				// if v.Kind() == reflect.Ptr {
-				// 	v = reflect.ValueOf(t).Elem()
-				// }
-				tmap := &tMap{
-					value:          v,
-					filteredFields: map[string]struct{}{},
-				}
-				err := tracked.trackMap(tmap)
-				if err != nil {
-					return fmt.Errorf("%s: %w", op, err)
-				}
-			}
-			tracked[ptr].filteredFields[segs[len(segs)-1]] = struct{}{}
-
-		case len(segs) > 2:
-			i, err := pointerstructure.Get(t, strings.Join(segs[:len(segs)-1], "/"))
-			if err != nil {
-
-			}
-			mrv := reflect.ValueOf(i)
-			if _, ok := tracked[mrv.Pointer()]; !ok {
-				tmap := &tMap{
-					value:          mrv,
-					filteredFields: map[string]struct{}{},
-				}
-				if err := tracked.trackMap(tmap); err != nil {
-					return fmt.Errorf("%s: %w", op, err)
-				}
-			}
-			tracked[mrv.Pointer()].filteredFields[segs[len(segs)-1]] = struct{}{}
-
-		default:
-			// not reachable...
+		if err := trackedMaps.trackTaggable(t, pt.Pointer); err != nil {
+			return fmt.Errorf("%s: %w", op, err)
 		}
 	}
-	if err := tracked.processUnfiltered(ctx, ef, filterOverrides, opt...); err != nil {
-		panic(err)
+	if err := trackedMaps.processUnfiltered(ctx, ef, filterOverrides, opt...); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
 	}
 
 	return nil
@@ -508,7 +470,6 @@ func (ef *Filter) filterValue(ctx context.Context, fv reflect.Value, classificat
 		return fmt.Errorf("%s: missing classification tag: %w", op, ErrInvalidParameter)
 	case classificationTag.Classification == PublicClassification || classificationTag.Operation == NoOperation:
 		return nil
-
 	}
 
 	// check for nil value (prevent panics)

--- a/filters/encrypt/filter.go
+++ b/filters/encrypt/filter.go
@@ -170,6 +170,11 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 		}
 	}
 
+	// before we copy/dup the event, let's find out if we even need
+	if reflect.ValueOf(e.Payload).IsZero() {
+		return e, nil
+	}
+
 	// since the node will be modifying the event data (aka redact/encrypt), we
 	// need our own copy, otherwise we could be changing the event across other
 	// pipelines and nodes and creating a host of problems and race conditions.
@@ -188,9 +193,6 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 
 	switch payloadValue.Kind() {
 	case reflect.Ptr, reflect.Interface:
-		if payloadValue.IsNil() { // be sure it's not a nil interface
-			return e, nil
-		}
 		payloadValue = reflect.ValueOf(e.Payload).Elem()
 	}
 
@@ -200,6 +202,11 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 	// make a copy of the overrides before we begin processing this event, which
 	// will give us a consistent set of overrides for this event.
 	filterOverrides := ef.copyFilterOperationOverrides()
+
+	tm, err := newTrackedMaps()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
 
 	switch {
 	case pType == reflect.TypeOf("") || pType == reflect.TypeOf([]uint8{}):
@@ -211,7 +218,7 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 	case isTaggable:
-		if err := ef.filterTaggable(ctx, taggedInterface, filterOverrides, opts...); err != nil {
+		if err := ef.filterTaggable(ctx, taggedInterface, filterOverrides, tm, opts...); err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 		if pKind != reflect.Map {
@@ -219,7 +226,7 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 			// fields that need to be filtered, but be sure to ignore taggable
 			// on the next recursion or will be in an infinite loop
 			opts := append(opts, withIgnoreTaggable())
-			if err := ef.filterField(ctx, payloadValue, filterOverrides, opts...); err != nil {
+			if err := ef.filterField(ctx, payloadValue, filterOverrides, tm, opts...); err != nil {
 				return nil, fmt.Errorf("%s: %w", op, err)
 			}
 		}
@@ -238,19 +245,32 @@ func (ef *Filter) Process(ctx context.Context, e *eventlogger.Event) (*eventlogg
 				if f.Kind() == reflect.Ptr {
 					f = f.Elem()
 				}
-				if f.Kind() != reflect.Struct {
-					continue
+				if f.Type() == reflect.TypeOf(structpb.Struct{}) {
+					f = f.FieldByName("Fields")
 				}
-				if err := ef.filterField(ctx, f, filterOverrides, opts...); err != nil {
-					return nil, fmt.Errorf("%s: %w", op, err)
+				fkind := f.Kind()
+				switch {
+				case fkind == reflect.Map:
+					tm.trackMap(&tMap{value: f})
+				case fkind == reflect.Struct:
+					if err := ef.filterField(ctx, f, filterOverrides, tm, opts...); err != nil {
+						return nil, fmt.Errorf("%s: %w", op, err)
+					}
+				default:
+					// nothing reasonable yet...
 				}
 			}
 		}
 	case pKind == reflect.Struct:
-		if err := ef.filterField(ctx, payloadValue, filterOverrides, opts...); err != nil {
+		if err := ef.filterField(ctx, payloadValue, filterOverrides, tm, opts...); err != nil {
 			return nil, fmt.Errorf("%s: %w", op, err)
 		}
 	}
+
+	if err := tm.processUnfiltered(ctx, ef, filterOverrides, opts...); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
 	return e, nil
 }
 
@@ -269,7 +289,7 @@ func (ef *Filter) copyFilterOperationOverrides() map[DataClassification]FilterOp
 
 // filterField will recursively iterate over all the fields for a struct value
 // and filter them based on their DataClassification
-func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverrides map[DataClassification]FilterOperation, opt ...Option) error {
+func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverrides map[DataClassification]FilterOperation, tm *trackedMaps, opt ...Option) error {
 	const op = "event.(Filter).filterField"
 	// check for nil value (prevent panics)
 	if v == reflect.ValueOf(nil) {
@@ -282,7 +302,7 @@ func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverri
 	// taggable things and other fields.
 	if opts.withIgnoreTaggable {
 		var removeIdx int
-		for i := 0; i < len(opt)-1; i++ {
+		for i := 0; i < len(opt); i++ {
 			currentOpt := getOpts(opt[i])
 			if currentOpt.withIgnoreTaggable {
 				removeIdx = i
@@ -353,17 +373,25 @@ func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverri
 					if f.Kind() == reflect.Ptr {
 						f = f.Elem()
 					}
-					if f.Kind() != reflect.Struct {
-						continue
+					if f.Type() == reflect.TypeOf(&structpb.Struct{}) {
+						f = f.FieldByName("Fields")
 					}
-					if err := ef.filterField(ctx, f, filterOverrides, opt...); err != nil {
-						return err
+					fkind := f.Kind()
+					switch {
+					case fkind == reflect.Map:
+						tm.trackMap(&tMap{value: f})
+					case fkind == reflect.Struct:
+						if err := ef.filterField(ctx, f, filterOverrides, tm, opt...); err != nil {
+							return err
+						}
+					default:
+						// nothing reasonable yet...
 					}
 				}
 			}
 
 		case isTaggable && !opts.withIgnoreTaggable:
-			if err := ef.filterTaggable(ctx, taggedInterface, filterOverrides, opt...); err != nil {
+			if err := ef.filterTaggable(ctx, taggedInterface, filterOverrides, tm, opt...); err != nil {
 				return fmt.Errorf("%s: %w", op, err)
 			}
 			if fkind != reflect.Map {
@@ -371,15 +399,21 @@ func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverri
 				// fields that need to be filtered, but be sure to ignore taggable
 				// on the next recursion or will be in an infinite loop
 				opt = append(opt, withIgnoreTaggable())
-				if err := ef.filterField(ctx, field, filterOverrides, opt...); err != nil {
+				if err := ef.filterField(ctx, field, filterOverrides, tm, opt...); err != nil {
 					return fmt.Errorf("%s: %w", op, err)
 				}
 			}
 
 		// if the field is a struct
 		case fkind == reflect.Struct:
-			if err := ef.filterField(ctx, field, filterOverrides, opt...); err != nil {
+			if err := ef.filterField(ctx, field, filterOverrides, tm, opt...); err != nil {
 				return err
+			}
+
+		case fkind == reflect.Map: // this is the problem!!
+			t := &tMap{value: field}
+			if err := tm.trackMap(t); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
 			}
 		}
 	}
@@ -387,7 +421,7 @@ func (ef *Filter) filterField(ctx context.Context, v reflect.Value, filterOverri
 }
 
 // filterTaggable will filter data that implements the Taggable interface
-func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverrides map[DataClassification]FilterOperation, opt ...Option) error {
+func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverrides map[DataClassification]FilterOperation, tm *trackedMaps, opt ...Option) error {
 	const op = "event.(Filter).filterTaggable"
 	if t == nil {
 		return fmt.Errorf("%s: missing taggable interface: %w", op, ErrInvalidParameter)
@@ -396,7 +430,6 @@ func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverride
 	if err != nil {
 		return fmt.Errorf("%s: unable to get tags from taggable interface: %w", op, err)
 	}
-	trackedMaps, err := newTrackedMaps()
 	if err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
@@ -415,14 +448,10 @@ func (ef *Filter) filterTaggable(ctx context.Context, t Taggable, filterOverride
 		if err = ef.filterValue(ctx, rv, info, opt...); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}
-		if err := trackedMaps.trackTaggable(t, pt.Pointer); err != nil {
+		if err := tm.trackTaggable(t, pt.Pointer); err != nil {
 			return fmt.Errorf("%s: %w", op, err)
 		}
 	}
-	if err := trackedMaps.processUnfiltered(ctx, ef, filterOverrides, opt...); err != nil {
-		return fmt.Errorf("%s: %w", op, err)
-	}
-
 	return nil
 }
 

--- a/filters/encrypt/filter_test.go
+++ b/filters/encrypt/filter_test.go
@@ -57,7 +57,9 @@ func TestFilter_filterTaggable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			err := tt.ef.filterTaggable(ctx, tt.t, tt.ef.copyFilterOperationOverrides(), tt.opt...)
+			tm, err := newTrackedMaps()
+			require.NoError(err)
+			err = tt.ef.filterTaggable(ctx, tt.t, tt.ef.copyFilterOperationOverrides(), tm, tt.opt...)
 			if tt.wantErrIs != nil {
 				require.Error(err)
 				assert.ErrorIs(err, tt.wantErrIs)

--- a/filters/encrypt/filter_test.go
+++ b/filters/encrypt/filter_test.go
@@ -179,10 +179,10 @@ func TestFilter_filterValue(t *testing.T) {
 	}
 
 	testMap := TestTaggedMap{
-		"foo": "bar",
+		TestMapField: "bar",
 	}
 	testMap2 := TestTaggedMap{
-		"foo": "bar",
+		TestMapField: "bar",
 	}
 
 	wrapper := TestWrapper(t)
@@ -347,7 +347,7 @@ func TestFilter_filterValue(t *testing.T) {
 			opt:            []Option{withPointer(testMap, "/foo")},
 			classification: &tagInfo{Classification: SensitiveClassification, Operation: HmacSha256Operation},
 			wantValue: fmt.Sprintf("%s", map[string]interface{}{
-				"foo": TestHmacSha256(t, []byte("bar"), wrapper, []byte("salt"), []byte("info")),
+				TestMapField: TestHmacSha256(t, []byte("bar"), wrapper, []byte("salt"), []byte("info")),
 			}),
 		},
 		{
@@ -358,7 +358,7 @@ func TestFilter_filterValue(t *testing.T) {
 			classification: &tagInfo{Classification: SensitiveClassification, Operation: EncryptOperation},
 			decryptWrapper: wrapper,
 			wantValue: fmt.Sprintf("%s", map[string]interface{}{
-				"foo": TestHmacSha256(t, []byte("bar"), wrapper, []byte("salt"), []byte("info")),
+				TestMapField: TestHmacSha256(t, []byte("bar"), wrapper, []byte("salt"), []byte("info")),
 			}),
 		},
 		{
@@ -368,7 +368,7 @@ func TestFilter_filterValue(t *testing.T) {
 			opt:            []Option{withPointer(testMap2, "/foo")},
 			classification: &tagInfo{Classification: SensitiveClassification, Operation: RedactOperation},
 			wantValue: fmt.Sprintf("%s", map[string]interface{}{
-				"foo": RedactedData,
+				TestMapField: RedactedData,
 			}),
 		},
 		{

--- a/filters/encrypt/filter_test_pkg_test.go
+++ b/filters/encrypt/filter_test_pkg_test.go
@@ -272,14 +272,14 @@ func TestFilter_Process(t *testing.T) {
 				Type:      "test",
 				CreatedAt: now,
 				Payload: &encrypt.TestTaggedMap{
-					"foo": "bar",
+					encrypt.TestMapField: "bar",
 				},
 			},
 			wantEvent: &eventlogger.Event{
 				Type:      "test",
 				CreatedAt: now,
 				Payload: &encrypt.TestTaggedMap{
-					"foo": "<REDACTED>",
+					encrypt.TestMapField: "<REDACTED>",
 				},
 			},
 		},
@@ -290,14 +290,14 @@ func TestFilter_Process(t *testing.T) {
 				Type:      "test",
 				CreatedAt: now,
 				Payload: encrypt.TestTaggedMap{
-					"foo": "bar",
+					encrypt.TestMapField: "bar",
 				},
 			},
 			wantEvent: &eventlogger.Event{
 				Type:      "test",
 				CreatedAt: now,
 				Payload: encrypt.TestTaggedMap{
-					"foo": "<REDACTED>",
+					encrypt.TestMapField: "<REDACTED>",
 				},
 			},
 		},
@@ -311,7 +311,7 @@ func TestFilter_Process(t *testing.T) {
 					PublicId:          "id-12",
 					SensitiveUserName: "Alice Eve Doe",
 					TaggedMap: encrypt.TestTaggedMap{
-						"foo": "bar",
+						encrypt.TestMapField: "bar",
 					},
 				},
 			},
@@ -322,7 +322,7 @@ func TestFilter_Process(t *testing.T) {
 					PublicId:          "id-12",
 					SensitiveUserName: "Alice Eve Doe",
 					TaggedMap: encrypt.TestTaggedMap{
-						"foo": "<REDACTED>",
+						encrypt.TestMapField: "<REDACTED>",
 					},
 				},
 			},

--- a/filters/encrypt/filter_test_pkg_test.go
+++ b/filters/encrypt/filter_test_pkg_test.go
@@ -106,6 +106,7 @@ func TestFilter_Process(t *testing.T) {
 				protopayload.TaggedStringField:   structpb.NewStringValue("Tagged"),
 				protopayload.UntaggedStringField: structpb.NewStringValue("Untagged"),
 				protopayload.TaggedBytesField:    b,
+				protopayload.IntField:            structpb.NewNumberValue(10),
 			},
 		},
 		NontaggableAttributes: &structpb.Struct{
@@ -355,9 +356,12 @@ func TestFilter_Process(t *testing.T) {
 					taggable.UnclassifiedBytes = []byte(encrypt.RedactedData)
 					taggable.SecretBytesValue.Value = []byte(encrypt.RedactedData)
 					taggable.UnclassifiedBytesValue.Value = []byte(encrypt.RedactedData)
+					taggable.TaggableAttributes.Fields[protopayload.UntaggedStringField] = structpb.NewStringValue(encrypt.RedactedData)
 
 					taggable.TaggableAttributes.Fields[protopayload.TaggedStringField] = structpb.NewStringValue(encrypt.RedactedData) // overridden by Tags()
 					taggable.EmbeddedTaggable.ESecretString = encrypt.RedactedData
+					taggable.EmbeddedTaggable.ETaggableAttributes.Fields[protopayload.UntaggedStringField] = structpb.NewStringValue(encrypt.RedactedData)
+
 					return taggable
 				}(),
 			},
@@ -637,11 +641,17 @@ func TestFilter_Process(t *testing.T) {
 				return
 			}
 			require.NoError(err)
+			actualJson, err := json.Marshal(got)
+			require.NoError(err)
+			t.Log(string(actualJson))
+
 			if tt.setupWantEvent != nil {
 				tt.setupWantEvent(got)
 			}
-			actualJson, err := json.Marshal(got)
+			actualJson, err = json.Marshal(got)
 			require.NoError(err)
+			t.Log(string(actualJson))
+
 			wantJson, err := json.Marshal(tt.wantEvent)
 			require.NoError(err)
 			assert.JSONEq(string(wantJson), string(actualJson))

--- a/filters/encrypt/map.go
+++ b/filters/encrypt/map.go
@@ -43,6 +43,7 @@ type tMap struct {
 
 type trackedMaps map[uintptr]*tMap
 
+// newTrackedMaps will create a new trackedMaps
 func newTrackedMaps(tm ...*tMap) (trackedMaps, error) {
 	const op = "encrypt.(eventMaps).newTrackedMaps"
 	maps := make(trackedMaps, len(tm))
@@ -54,8 +55,7 @@ func newTrackedMaps(tm ...*tMap) (trackedMaps, error) {
 	return maps, nil
 }
 
-// trackMap will add the map reflect.Value to the list of tracked maps for the
-// event's payload.
+// trackMap will add the map to the list of tracked maps
 func (maps trackedMaps) trackMap(tm *tMap) error {
 	const op = "encrypt.(eventMaps).trackMap"
 	if tm == nil {
@@ -81,6 +81,7 @@ func (maps trackedMaps) trackMap(tm *tMap) error {
 	}
 }
 
+// unfiltered returns all the maps which haven't been tracked as filtered
 func (maps trackedMaps) unfiltered() []*tMap {
 	unfiltered := make([]*tMap, 0, len(maps))
 	for _, m := range maps {

--- a/filters/encrypt/map.go
+++ b/filters/encrypt/map.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
+	"github.com/mitchellh/pointerstructure"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -45,11 +47,11 @@ type trackedMaps map[uintptr]*tMap
 
 // newTrackedMaps will create a new trackedMaps
 func newTrackedMaps(tm ...*tMap) (trackedMaps, error) {
-	const op = "encrypt.(eventMaps).newTrackedMaps"
+	const op = "encrypt.(trackedMaps).newTrackedMaps"
 	maps := make(trackedMaps, len(tm))
 	for i, m := range tm {
 		if err := maps.trackMap(m); err != nil {
-			return nil, fmt.Errorf("%s: new map parameter # %d is not a valid: %w", op, i, err)
+			return nil, fmt.Errorf("%s: new map parameter #%d is not a valid: %w", op, i, err)
 		}
 	}
 	return maps, nil
@@ -57,12 +59,14 @@ func newTrackedMaps(tm ...*tMap) (trackedMaps, error) {
 
 // trackMap will add the map to the list of tracked maps
 func (maps trackedMaps) trackMap(tm *tMap) error {
-	const op = "encrypt.(eventMaps).trackMap"
+	const op = "encrypt.(trackedMaps).trackMap"
 	if tm == nil {
 		return fmt.Errorf("%s: missing map: %w", op, ErrInvalidParameter)
 	}
+	if !tm.value.IsValid() {
+		return fmt.Errorf("%s: map value is missing: %w", op, ErrInvalidParameter)
+	}
 
-	tmPtr := tm.value.Pointer()
 	tmKind := tm.value.Kind()
 
 	var isMapPtr bool
@@ -71,10 +75,7 @@ func (maps trackedMaps) trackMap(tm *tMap) error {
 	}
 	switch {
 	case isMapPtr || tmKind == reflect.Map || tm.value.Type() == reflect.TypeOf(&structpb.Struct{}):
-		if tm.value.IsNil() {
-			return fmt.Errorf("%s: map value is nil: %w", op, ErrInvalidParameter)
-		}
-		maps[tmPtr] = tm
+		maps[tm.value.Pointer()] = tm // we might need to move this if we ever change the value of tm to tm.Elem()
 		return nil
 	default:
 		return fmt.Errorf("%s: %s is not a valid parameter type: %w", op, tm.value.Type(), ErrInvalidParameter)
@@ -94,9 +95,10 @@ func (maps trackedMaps) unfiltered() []*tMap {
 }
 
 // processUnfiltered will process/filter all the maps being tracked which
-// haven't been tracked as filtered and it will mark them as filtered.
+// haven't been tracked as filtered and it will mark them as filtered.  It will
+// skip any fields within a map which have already been marked as filtered.
 func (maps trackedMaps) processUnfiltered(ctx context.Context, ef *Filter, filterOverrides map[DataClassification]FilterOperation, opt ...Option) error {
-	const op = "encrypt.(eventMaps).processUnfiltered"
+	const op = "encrypt.(trackedMaps).processUnfiltered"
 	if ef == nil {
 		return fmt.Errorf("%s: missing filter node: %w", op, ErrInvalidParameter)
 	}
@@ -127,66 +129,198 @@ func (maps trackedMaps) processUnfiltered(ctx context.Context, ef *Filter, filte
 				}
 			}
 			field := v.MapIndex(key)
+
+			var fPtr bool
+			if field.Kind() == reflect.Ptr {
+				field = field.Elem()
+				fPtr = true
+			}
+			if field.Kind() == reflect.Interface {
+				field = field.Elem()
+			}
+
 			ftype := field.Type()
 			fkind := field.Kind()
 
 			switch {
 			// if the field is a string or []byte then we just need to sanitize it
-			case ftype == reflect.TypeOf("") || ftype == reflect.TypeOf([]uint8{}):
-				if err := ef.filterValue(ctx, field, classificationTag, opt...); err != nil {
-					return fmt.Errorf("%s: %w", op, err)
+			case ftype == reflect.TypeOf(""):
+				s := field.String()
+				f := reflect.Indirect(reflect.ValueOf(&s))
+				if err := ef.filterValue(ctx, f, classificationTag, opt...); err != nil {
+					return fmt.Errorf("%s: unable to filter string: %w", op, err)
 				}
-			case ftype == reflect.TypeOf(wrapperspb.StringValue{}) || ftype == reflect.TypeOf(wrapperspb.BytesValue{}):
-				if err := ef.filterValue(ctx, field.FieldByName("Value"), classificationTag, opt...); err != nil {
-					return err
+				v.SetMapIndex(key, f)
+
+			case ftype == reflect.TypeOf([]uint8{}):
+				s := field.Bytes()
+				f := reflect.Indirect(reflect.ValueOf(&s))
+				if err := ef.filterValue(ctx, f, classificationTag, opt...); err != nil {
+					return fmt.Errorf("%s: unable to filter []byte: %w", op, err)
 				}
-			// if the field is a slice
+				v.SetMapIndex(key, f)
+
+			case ftype == reflect.TypeOf(wrapperspb.StringValue{}):
+				s := field.FieldByName("Value").String()
+				f := reflect.Indirect(reflect.ValueOf(&s))
+				if err := ef.filterValue(ctx, f, classificationTag, opt...); err != nil {
+					return fmt.Errorf("%s: unable to filter wrappers string value: %w", op, err)
+				}
+				vv := reflect.ValueOf(wrapperspb.StringValue{Value: s})
+				v.SetMapIndex(key, vv)
+
+			case ftype == reflect.TypeOf(wrapperspb.BytesValue{}):
+				s := field.FieldByName("Value").Bytes()
+				f := reflect.Indirect(reflect.ValueOf(&s))
+				if err := ef.filterValue(ctx, f, classificationTag, opt...); err != nil {
+					return fmt.Errorf("%s: unable to filter wrappers bytes value: %w", op, err)
+				}
+				vv := reflect.ValueOf(wrapperspb.BytesValue{Value: s})
+				v.SetMapIndex(key, vv)
+
 			case fkind == reflect.Slice:
 				switch {
 				// if the field is a slice of string or slice of []byte
 				case ftype == reflect.TypeOf([]string{}) || ftype == reflect.TypeOf([][]uint8{}):
 					if err := ef.filterSlice(ctx, classificationTag, field, opt...); err != nil {
-						return fmt.Errorf("%s: %w", op, err)
+						return fmt.Errorf("%s: unable to filter slice of strings: %w", op, err)
 					}
 				// if the field is a slice of structs, recurse through them...
 				default:
 					for i := 0; i < field.Len(); i++ {
 						f := field.Index(i)
+						if f.Kind() == reflect.Interface {
+							f.Elem()
+						}
 						if f.Kind() == reflect.Ptr {
 							f = f.Elem()
 						}
-						if f.Kind() != reflect.Struct {
-							continue
+						newMaps, err := newTrackedMaps()
+						if err != nil {
+							return fmt.Errorf("%s: unable to create new tracked maps for slice: %w", op, err)
 						}
-						if err := ef.filterField(ctx, f, filterOverrides, opt...); err != nil {
-							return fmt.Errorf("%s: %w", op, err)
+						switch {
+						case f.Kind() == reflect.Struct:
+							newOpts := make([]Option, 0, len(opt))
+							newOpts = append(newOpts, opt...)
+							newOpts = append(newOpts, withTrackedMaps(newMaps))
+							if err := ef.filterField(ctx, f, filterOverrides, newOpts...); err != nil {
+								return fmt.Errorf("%s: unable to filter slice of structs: %w", op, err)
+							}
+
+						case f.Kind() == reflect.Map:
+							newMaps.trackMap(&tMap{
+								value: f,
+							})
+
+						default:
+							// for now, there's no default... perhaps in the
+							// future there will be a reasonable default.
+						}
+						if err := newMaps.processUnfiltered(ctx, ef, filterOverrides, opt...); err != nil {
+							return fmt.Errorf("%s: unable to process maps found in slice: %w", op, err)
 						}
 					}
-				}
-			// if the field is a struct
-			case fkind == reflect.Struct:
-				if err := ef.filterField(ctx, field, filterOverrides, opt...); err != nil {
-					return fmt.Errorf("%s: %w", op, err)
 				}
 
-			case ftype == reflect.TypeOf(&structpb.Value{}):
-				i := field.Interface().(*structpb.Value)
-				switch {
-				case reflect.TypeOf(i.Kind) == reflect.TypeOf(&structpb.Value_StringValue{}):
-					s := i.GetStringValue()
-					vv := reflect.Indirect(reflect.ValueOf(&s))
-					if err := ef.filterValue(ctx, vv, &tagInfo{}, opt...); err != nil {
-						return fmt.Errorf("%s: %w", op, err)
-					}
-					v.SetMapIndex(key, reflect.ValueOf(structpb.NewStringValue(vv.String())))
+			case fkind == reflect.Struct:
+				f := field
+				if err := ef.filterField(ctx, f, filterOverrides, opt...); err != nil {
+					return fmt.Errorf("%s: unable to filter struct: %w", op, err)
 				}
+				if fPtr {
+					f = field.Addr()
+				}
+				v.SetMapIndex(key, f)
+
+			case fkind == reflect.Map:
+				newMaps, err := newTrackedMaps(&tMap{value: field})
+				if err != nil {
+					return fmt.Errorf("%s: unable to filter map: %w", op, err)
+				}
+				if err := newMaps.processUnfiltered(ctx, ef, filterOverrides, opt...); err != nil {
+					return fmt.Errorf("%s: unable to process maps found in map: %w", op, err)
+				}
+
 			default:
-				// intentional no-op
+				// at this point, there's no reasonable default.. wish there was.
 			}
+
+			// if you want to examine the "after filter" value you'll need to
+			// look at the v.MapIndex(key) directly, not the field.
 		}
 		// very important to mark the current map as filtered before iterating
 		m.filtered = true
 		m.filteredFields = nil
+	}
+	return nil
+}
+
+func (maps trackedMaps) trackTaggable(taggable Taggable, pointer string) error {
+	const (
+		op            = "encrypt.(trackedMaps).trackTaggable"
+		pathDelimiter = "/"
+		badPath       = 1
+		taggableMap   = 2
+	)
+	if taggable == nil {
+		return fmt.Errorf("%s: missing taggable: %w", op, ErrInvalidParameter)
+	}
+	if pointer == "" {
+		return fmt.Errorf("%s: missing pointer: %w", op, ErrInvalidParameter)
+	}
+
+	// need to determine what maps are referenced in this pointer tag, so spit
+	// on the pointerstruct path delimiter of "/"
+	segs := strings.Split(pointer, pathDelimiter)
+	switch len(segs) {
+	case badPath:
+		return fmt.Errorf("%s: invalid taggable pointer: %w", op, ErrInvalidParameter)
+
+	case taggableMap:
+		// the path just pointed at a field within taggable
+		ptr := reflect.ValueOf(taggable).Pointer()
+
+		// Are we already tracking this map?
+		if _, ok := maps[ptr]; !ok {
+			v := reflect.ValueOf(taggable)
+			// not sure if we need to worry if v.Kind() is a reflect.Ptr and
+			// then get the elem... so for now, I'm going to skip that.
+			tmap := &tMap{
+				value:          v,
+				filteredFields: map[string]struct{}{},
+			}
+			err := maps.trackMap(tmap)
+			if err != nil {
+				return fmt.Errorf("%s: unable to track taggable map: %w", op, err)
+			}
+		}
+		// now, we're just going to mark a field referenced by the pointer
+		// within the map as "filtered"
+		maps[ptr].filteredFields[segs[len(segs)-1]] = struct{}{}
+
+	default:
+		// default is a map that we need to go get via the pointer
+		foundMap, err := pointerstructure.Get(taggable, strings.Join(segs[:len(segs)-1], "/"))
+		if err != nil {
+			return fmt.Errorf("%s: %w", op, err)
+		}
+		v := reflect.ValueOf(foundMap)
+		ptr := v.Pointer()
+
+		// Are we already tracking this map?
+		if _, ok := maps[ptr]; !ok {
+			tmap := &tMap{
+				value:          v,
+				filteredFields: map[string]struct{}{},
+			}
+			if err := maps.trackMap(tmap); err != nil {
+				return fmt.Errorf("%s: unable to track map from pointer struct: %w", op, err)
+			}
+		}
+		// now, we're just going to mark a field referenced by the pointer
+		// within the map as "filtered"
+		maps[ptr].filteredFields[segs[len(segs)-1]] = struct{}{}
 	}
 	return nil
 }

--- a/filters/encrypt/map.go
+++ b/filters/encrypt/map.go
@@ -1,5 +1,14 @@
 package encrypt
 
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
 // PointerTag provides the pointerstructure pointer string to get/set a key
 // within a map[string]interface{} along with its DataClassification and
 // FilterOperation.
@@ -24,4 +33,159 @@ type Taggable interface {
 
 	// Tags will return a set of pointer tags for the map
 	Tags() ([]PointerTag, error)
+}
+
+type tMap struct {
+	value          reflect.Value
+	filtered       bool                // true when all fields have been filtered.
+	filteredFields map[string]struct{} // not nil when only some fields have been filtered
+}
+
+type trackedMaps map[uintptr]*tMap
+
+func newTrackedMaps(tm ...*tMap) (trackedMaps, error) {
+	const op = "encrypt.(eventMaps).newTrackedMaps"
+	maps := make(trackedMaps, len(tm))
+	for i, m := range tm {
+		if err := maps.trackMap(m); err != nil {
+			return nil, fmt.Errorf("%s: new map parameter # %d is not a valid: %w", op, i, err)
+		}
+	}
+	return maps, nil
+}
+
+// trackMap will add the map reflect.Value to the list of tracked maps for the
+// event's payload.
+func (maps trackedMaps) trackMap(tm *tMap) error {
+	const op = "encrypt.(eventMaps).trackMap"
+	if tm == nil {
+		return fmt.Errorf("%s: missing map: %w", op, ErrInvalidParameter)
+	}
+
+	tmPtr := tm.value.Pointer()
+	tmKind := tm.value.Kind()
+
+	var isMapPtr bool
+	if tmKind == reflect.Ptr && tm.value.Elem().Kind() == reflect.Map {
+		isMapPtr = true
+	}
+	switch {
+	case isMapPtr || tmKind == reflect.Map || tm.value.Type() == reflect.TypeOf(&structpb.Struct{}):
+		if tm.value.IsNil() {
+			return fmt.Errorf("%s: map value is nil: %w", op, ErrInvalidParameter)
+		}
+		maps[tmPtr] = tm
+		return nil
+	default:
+		return fmt.Errorf("%s: %s is not a valid parameter type: %w", op, tm.value.Type(), ErrInvalidParameter)
+	}
+}
+
+func (maps trackedMaps) unfiltered() []*tMap {
+	unfiltered := make([]*tMap, 0, len(maps))
+	for _, m := range maps {
+		if m.filtered {
+			continue
+		}
+		unfiltered = append(unfiltered, m)
+	}
+	return unfiltered
+}
+
+// processUnfiltered will process/filter all the maps being tracked which
+// haven't been tracked as filtered and it will mark them as filtered.
+func (maps trackedMaps) processUnfiltered(ctx context.Context, ef *Filter, filterOverrides map[DataClassification]FilterOperation, opt ...Option) error {
+	const op = "encrypt.(eventMaps).processUnfiltered"
+	if ef == nil {
+		return fmt.Errorf("%s: missing filter node: %w", op, ErrInvalidParameter)
+	}
+
+	for _, m := range maps.unfiltered() {
+		// we will mark the map as filtered at the bottom of this loop.
+		var v reflect.Value
+		switch {
+		case m.value.Type() == reflect.TypeOf(&structpb.Struct{}):
+			v = m.value.Elem().FieldByName("Fields")
+		case m.value.Kind() == reflect.Ptr:
+			v = m.value.Elem()
+		default:
+			v = m.value
+		}
+		if v.Kind() != reflect.Map {
+			return fmt.Errorf("%s: unfiltered value (%s) is a not a map: %w", op, v.Kind(), ErrInvalidParameter)
+		}
+
+		classificationTag := &tagInfo{
+			Classification: UnknownClassification,
+			Operation:      UnknownOperation,
+		}
+		for _, key := range v.MapKeys() {
+			if m.filteredFields != nil {
+				if _, ok := m.filteredFields[key.String()]; ok {
+					continue // already filtered
+				}
+			}
+			field := v.MapIndex(key)
+			ftype := field.Type()
+			fkind := field.Kind()
+
+			switch {
+			// if the field is a string or []byte then we just need to sanitize it
+			case ftype == reflect.TypeOf("") || ftype == reflect.TypeOf([]uint8{}):
+				if err := ef.filterValue(ctx, field, classificationTag, opt...); err != nil {
+					return fmt.Errorf("%s: %w", op, err)
+				}
+			case ftype == reflect.TypeOf(wrapperspb.StringValue{}) || ftype == reflect.TypeOf(wrapperspb.BytesValue{}):
+				if err := ef.filterValue(ctx, field.FieldByName("Value"), classificationTag, opt...); err != nil {
+					return err
+				}
+			// if the field is a slice
+			case fkind == reflect.Slice:
+				switch {
+				// if the field is a slice of string or slice of []byte
+				case ftype == reflect.TypeOf([]string{}) || ftype == reflect.TypeOf([][]uint8{}):
+					if err := ef.filterSlice(ctx, classificationTag, field, opt...); err != nil {
+						return fmt.Errorf("%s: %w", op, err)
+					}
+				// if the field is a slice of structs, recurse through them...
+				default:
+					for i := 0; i < field.Len(); i++ {
+						f := field.Index(i)
+						if f.Kind() == reflect.Ptr {
+							f = f.Elem()
+						}
+						if f.Kind() != reflect.Struct {
+							continue
+						}
+						if err := ef.filterField(ctx, f, filterOverrides, opt...); err != nil {
+							return fmt.Errorf("%s: %w", op, err)
+						}
+					}
+				}
+			// if the field is a struct
+			case fkind == reflect.Struct:
+				if err := ef.filterField(ctx, field, filterOverrides, opt...); err != nil {
+					return fmt.Errorf("%s: %w", op, err)
+				}
+
+			case ftype == reflect.TypeOf(&structpb.Value{}):
+				i := field.Interface().(*structpb.Value)
+				switch {
+				case reflect.TypeOf(i.Kind) == reflect.TypeOf(&structpb.Value_StringValue{}):
+					s := i.GetStringValue()
+					vv := reflect.Indirect(reflect.ValueOf(&s))
+					if err := ef.filterValue(ctx, vv, &tagInfo{}, opt...); err != nil {
+						return fmt.Errorf("%s: %w", op, err)
+					}
+					v.SetMapIndex(key, reflect.ValueOf(structpb.NewStringValue(vv.String())))
+				}
+			default:
+				// intentional no-op
+			}
+		}
+		// very important to mark the current map as filtered before iterating
+		m.filtered = true
+		m.filteredFields = nil
+	}
+	return nil
 }

--- a/filters/encrypt/map_test.go
+++ b/filters/encrypt/map_test.go
@@ -1,0 +1,520 @@
+package encrypt
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func Test_newTrackedMaps(t *testing.T) {
+	testTMap := reflect.ValueOf(map[string]string{"eve": "alice"})
+
+	tests := []struct {
+		name            string
+		tm              []*tMap
+		want            trackedMaps
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "no-args",
+			want: trackedMaps{},
+		},
+		{
+			name: "bad-map-value",
+			tm: []*tMap{
+				{
+					value: reflect.ValueOf(""),
+				},
+			},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "string is not a valid parameter type",
+		},
+		{
+			name:            "nil-map",
+			tm:              []*tMap{nil},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing map",
+		},
+		{
+			name:            "nil-map-value",
+			tm:              []*tMap{{}},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "map value is missing",
+		},
+		{
+			name: "valid",
+			tm: []*tMap{
+				{
+					value:    testTMap,
+					filtered: true,
+				},
+			},
+			want: trackedMaps{
+				testTMap.Pointer(): &tMap{
+					value:    testTMap,
+					filtered: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := newTrackedMaps(tt.tm...)
+			if tt.wantErr {
+				require.Error(err)
+				assert.Nil(got)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					assert.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+func Test_trackedMaps_unfiltered(t *testing.T) {
+	m1 := reflect.ValueOf(map[string]string{"bob": "eve"})
+	m2 := reflect.ValueOf(map[string]string{"eve": "alice"})
+
+	tests := []struct {
+		name string
+		tm   trackedMaps
+		want []*tMap
+	}{
+		{
+			name: "simple",
+			tm: trackedMaps{
+				m1.Pointer(): &tMap{value: m1, filtered: true},
+				m2.Pointer(): &tMap{value: m2, filtered: false},
+			},
+			want: []*tMap{
+				{value: m2, filtered: false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := tt.tm.unfiltered()
+			assert.Equal(tt.want, got)
+		})
+	}
+}
+
+func Test_trackedMaps_trackMap(t *testing.T) {
+	testTMap := reflect.ValueOf(map[string]string{"eve": "alice"})
+
+	tests := []struct {
+		name            string
+		tm              trackedMaps
+		m               *tMap
+		wantTm          trackedMaps
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-map",
+			tm:              trackedMaps{},
+			m:               nil,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing map",
+		},
+		{
+			name:            "missing-value",
+			tm:              trackedMaps{},
+			m:               &tMap{},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "map value is missing",
+		},
+		{
+			name: "not-valid-value",
+			tm:   trackedMaps{},
+			m: &tMap{
+				value: reflect.ValueOf(""),
+			},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "string is not a valid parameter type",
+		},
+		{
+			name: "valid",
+			tm:   trackedMaps{},
+			m: &tMap{
+				value: testTMap,
+			},
+			wantTm: trackedMaps{
+				testTMap.Pointer(): &tMap{
+					value: testTMap,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tt.tm.trackMap(tt.m)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					assert.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.wantTm, tt.tm)
+		})
+	}
+}
+
+func Test_trackedMaps_trackTaggable(t *testing.T) {
+	// testTMap := reflect.ValueOf(map[string]string{"eve": "alice"})
+
+	testMap := TestTaggedMap{
+		TestMapField:       "alice",
+		TestMapField + "2": "bob",
+	}
+	tests := []struct {
+		name            string
+		tm              trackedMaps
+		taggable        Taggable
+		pointer         string
+		wantTm          trackedMaps
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-pointer",
+			tm:              trackedMaps{},
+			taggable:        TestTaggedMap{},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing pointer",
+		},
+		{
+			name:            "missing-taggable",
+			tm:              trackedMaps{},
+			pointer:         "/" + TestMapField,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing taggable",
+		},
+		{
+			name:            "bad-path",
+			tm:              trackedMaps{},
+			pointer:         "missing-initial-path-delimiter",
+			taggable:        TestTaggedMap{},
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "invalid taggable pointer",
+		},
+		{
+			name:            "pointer-path-invalid",
+			tm:              trackedMaps{},
+			pointer:         "/unknownMap/" + TestMapField,
+			taggable:        TestTaggedMap{},
+			wantErr:         true,
+			wantErrContains: "/unknownMap at part 0: couldn't find key",
+		},
+		{
+			name: "valid",
+			tm: trackedMaps{
+				reflect.ValueOf(testMap).Pointer(): &tMap{
+					value:          reflect.ValueOf(testMap),
+					filteredFields: map[string]struct{}{},
+				},
+			},
+			pointer:  "/" + TestMapField,
+			taggable: testMap,
+			wantTm: trackedMaps{
+				reflect.ValueOf(testMap).Pointer(): &tMap{
+					value: reflect.ValueOf(testMap),
+					filteredFields: map[string]struct{}{
+						TestMapField: {},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tt.tm.trackTaggable(tt.taggable, tt.pointer)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					assert.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tt.wantTm, tt.tm)
+		})
+	}
+}
+
+func Test_trackedMaps_processUnfiltered(t *testing.T) {
+	ctx := context.Background()
+	ef := &Filter{}
+
+	overrides := DefaultFilterOperations()
+	for class, op := range overrides {
+		switch op {
+		case EncryptOperation, HmacSha256Operation:
+			overrides[class] = RedactOperation
+		}
+	}
+
+	newTm := func(m interface{}) trackedMaps {
+		return trackedMaps{
+			reflect.ValueOf(m).Pointer(): &tMap{
+				value: reflect.ValueOf(m),
+			},
+		}
+	}
+
+	testStructpbStruct, err := structpb.NewStruct(map[string]interface{}{
+		TestMapField: "alice",
+	})
+	require.NoError(t, err)
+
+	type testStruct struct {
+		Name string
+	}
+
+	tests := []struct {
+		name            string
+		ef              *Filter
+		tm              trackedMaps
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-filter",
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing filter node",
+		},
+		{
+			name:            "not-a-map",
+			ef:              ef,
+			tm:              newTm([]string{"string-slice"}),
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "unfiltered value (slice) is a not a map",
+		},
+		{
+			name: "no-tracked-maps",
+			ef:   ef,
+			tm:   trackedMaps{},
+		},
+		{
+			name: "map-string-interface",
+			ef:   ef,
+			tm: newTm(map[string]interface{}{
+				TestMapField: "alice",
+			}),
+		},
+		{
+			name: "map-string-string",
+			ef:   ef,
+			tm: newTm(map[string]string{
+				TestMapField: "alice",
+			}),
+		},
+		{
+			name: "map-string-byte",
+			ef:   ef,
+			tm: newTm(map[string][]byte{
+				TestMapField: []byte("alice"),
+			}),
+		},
+		{
+			name: "map-string-wrapperspb-string-value",
+			ef:   ef,
+			tm: newTm(map[string]wrapperspb.StringValue{
+				TestMapField: {Value: "alice"},
+			}),
+		},
+		{
+			name: "map-string-wrapperspb-bytes-value",
+			ef:   ef,
+			tm: newTm(map[string]wrapperspb.BytesValue{
+				TestMapField: {Value: []byte("alice")},
+			}),
+		},
+		{
+			name: "map-string-structpb-struct",
+			ef:   ef,
+			tm:   newTm(testStructpbStruct),
+		},
+		{
+			name: "map-string-string-slice",
+			ef:   ef,
+			tm: newTm(map[string][]string{
+				TestMapField: {"alice"},
+			}),
+		},
+		{
+			name: "map-string-string-bytes",
+			ef:   ef,
+			tm: newTm(map[string][]byte{
+				TestMapField: []byte("alice"),
+			}),
+		},
+		{
+			name: "map-string-struct-name",
+			ef:   ef,
+			tm: newTm(map[string]*testStruct{
+				TestMapField: {Name: "alice"},
+			}),
+		},
+		{
+			name: "map-string-slice-struct-name",
+			ef:   ef,
+			tm: newTm(map[string][]*testStruct{
+				TestMapField: {
+					{Name: "alice"},
+				},
+			}),
+		},
+		{
+			name: "map-string-slice-map-string-string",
+			ef:   ef,
+			tm: newTm(map[string][]map[string]string{
+				TestMapField: {
+					{
+						TestMapField: "alice",
+					},
+				},
+			}),
+		},
+		{
+			name: "map-string-map-string-string",
+			ef:   ef,
+			tm: newTm(map[string]map[string]string{
+				TestMapField: {
+					TestMapField: "alice",
+				},
+			}),
+		},
+		{
+			name: "map-string-map-structpbvalue",
+			ef:   ef,
+			tm: newTm(map[string]*structpb.Value{
+				TestMapField: structpb.NewStringValue("alice"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tt.tm.processUnfiltered(ctx, tt.ef, overrides)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					assert.Contains(err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			for _, m := range tt.tm {
+				mValue := m.value
+				if m.value.Type() == reflect.TypeOf(&structpb.Struct{}) {
+					mValue = m.value.Elem().FieldByName("Fields")
+				}
+				for _, k := range mValue.MapKeys() {
+					v := mValue.MapIndex(k)
+					gotJson, err := json.Marshal(v.Interface())
+					require.NoError(err)
+					switch {
+					case v.Type() == reflect.TypeOf([]string{}):
+						wantJson, err := json.Marshal([]string{RedactedData})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf([]uint8{}):
+						assert.Equal(reflect.ValueOf([]byte(RedactedData)).Bytes(), v.Bytes())
+
+					case v.Type() == reflect.TypeOf(wrapperspb.StringValue{}):
+						wantJson, err := json.Marshal(wrapperspb.StringValue{Value: RedactedData})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf(wrapperspb.BytesValue{}):
+						wantJson, err := json.Marshal(wrapperspb.BytesValue{Value: []byte(RedactedData)})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf(&testStruct{}):
+						wantJson, err := json.Marshal(&testStruct{RedactedData})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf([]*testStruct{}):
+						wantJson, err := json.Marshal([]*testStruct{{RedactedData}})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf([]map[string]string{}):
+						wantJson, err := json.Marshal([]map[string]string{{TestMapField: RedactedData}})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf(map[string]string{}):
+						wantJson, err := json.Marshal(map[string]string{TestMapField: RedactedData})
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					case v.Type() == reflect.TypeOf(map[string]*structpb.Struct{}):
+						wantJson, err := json.Marshal(
+							map[string]*structpb.Value{
+								TestMapField: structpb.NewStringValue("alice"),
+							},
+						)
+
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+
+					default:
+						t.Log("default case for type...value: ", v.Type(), "...", v)
+						wantJson, err := json.Marshal(RedactedData)
+						require.NoError(err)
+						assert.JSONEq(string(wantJson), string(gotJson))
+					}
+				}
+			}
+		})
+	}
+}

--- a/filters/encrypt/options.go
+++ b/filters/encrypt/options.go
@@ -79,9 +79,3 @@ func withIgnoreTaggable() Option {
 		o.withIgnoreTaggable = true
 	}
 }
-
-func withTrackedMaps(tm *trackedMaps) Option {
-	return func(o *options) {
-		o.withTrackedMaps = tm
-	}
-}

--- a/filters/encrypt/options.go
+++ b/filters/encrypt/options.go
@@ -26,6 +26,7 @@ type options struct {
 	withFilterOperations     map[DataClassification]FilterOperation
 	withPointerstructureInfo *pointerstructureInfo
 	withIgnoreTaggable       bool
+	withTrackedMaps          trackedMaps
 }
 
 func getDefaultOptions() options {
@@ -76,5 +77,11 @@ func withPointer(i interface{}, pointer string) Option {
 func withIgnoreTaggable() Option {
 	return func(o *options) {
 		o.withIgnoreTaggable = true
+	}
+}
+
+func withTrackedMaps(tm trackedMaps) Option {
+	return func(o *options) {
+		o.withTrackedMaps = tm
 	}
 }

--- a/filters/encrypt/options.go
+++ b/filters/encrypt/options.go
@@ -26,7 +26,7 @@ type options struct {
 	withFilterOperations     map[DataClassification]FilterOperation
 	withPointerstructureInfo *pointerstructureInfo
 	withIgnoreTaggable       bool
-	withTrackedMaps          trackedMaps
+	withTrackedMaps          *trackedMaps
 }
 
 func getDefaultOptions() options {
@@ -80,7 +80,7 @@ func withIgnoreTaggable() Option {
 	}
 }
 
-func withTrackedMaps(tm trackedMaps) Option {
+func withTrackedMaps(tm *trackedMaps) Option {
 	return func(o *options) {
 		o.withTrackedMaps = tm
 	}

--- a/filters/encrypt/options_test.go
+++ b/filters/encrypt/options_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Test_getOpts provides unit tests for getOpts and all the options
@@ -64,15 +63,6 @@ func Test_getOpts(t *testing.T) {
 		opts := getOpts(withIgnoreTaggable())
 		testOpts := getDefaultOptions()
 		testOpts.withIgnoreTaggable = true
-		assert.Equal(opts, testOpts)
-	})
-	t.Run("withTrackedMaps", func(t *testing.T) {
-		assert, require := assert.New(t), require.New(t)
-		tm, err := newTrackedMaps()
-		require.NoError(err)
-		opts := getOpts(withTrackedMaps(tm))
-		testOpts := getDefaultOptions()
-		testOpts.withTrackedMaps = tm
 		assert.Equal(opts, testOpts)
 	})
 }

--- a/filters/encrypt/options_test.go
+++ b/filters/encrypt/options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test_getOpts provides unit tests for getOpts and all the options
@@ -63,6 +64,15 @@ func Test_getOpts(t *testing.T) {
 		opts := getOpts(withIgnoreTaggable())
 		testOpts := getDefaultOptions()
 		testOpts.withIgnoreTaggable = true
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("withTrackedMaps", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		tm, err := newTrackedMaps()
+		require.NoError(err)
+		opts := getOpts(withTrackedMaps(tm))
+		testOpts := getDefaultOptions()
+		testOpts.withTrackedMaps = tm
 		assert.Equal(opts, testOpts)
 	})
 }

--- a/filters/encrypt/options_test.go
+++ b/filters/encrypt/options_test.go
@@ -48,7 +48,7 @@ func Test_getOpts(t *testing.T) {
 	t.Run("withPointer", func(t *testing.T) {
 		assert := assert.New(t)
 		m := TestTaggedMap{
-			"foo": "bar",
+			TestMapField: "bar",
 		}
 		opts := getOpts(withPointer(m, "/foo"))
 		testOpts := getDefaultOptions()

--- a/filters/encrypt/testing/resources/protopayload/taggable.go
+++ b/filters/encrypt/testing/resources/protopayload/taggable.go
@@ -8,6 +8,7 @@ const (
 	TaggedStringField   = "tagged_string_field"
 	UntaggedStringField = "not_tagged_string"
 	TaggedBytesField    = "tagged_bytes_field"
+	IntField            = "int_field"
 )
 
 // Tags satisfy the encrypt.Taggable interface and return the "tagged"


### PR DESCRIPTION
Currently, map fields are only filtered if a `Taggable` interface is implemented which includes the map. This is efficient, but could result in an inadvertent leak of sensitive and/or secret data. This PR changes that behavior by tracking all maps which are encountered while processing the event and before returning, it filters all the remaining unfiltered maps fields.