### PR TITLE
allow not appending timestamp to current log file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...

--- a/filters/gated/gated_test.go
+++ b/filters/gated/gated_test.go
@@ -451,7 +451,7 @@ func TestGatedFilter_Now(t *testing.T) {
 		n := time.Now()
 		got := gf.Now()
 		assert.True(got.Equal(time.Now()) || got.Before(time.Now()))
-		assert.True(got.After(n))
+		assert.True(got.Equal(n) || got.After(n))
 	})
 	t.Run("override-now", func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
Backward compatible version of #62 -- This version does *not* change the
default behavior. Users must opt in to new behavior.

This patch updates the file sink to allow *not* appending the timestamp
on the current log file. In this mode the timestamp is only appended
when the file is rotated.

This matches the behavior:

- Implemented in Nomad v1.1.4 with hashicorp/nomad#11070
- Requested in hashicorp/nomad#11061

> The following example configures a destination called "My Sink" which
> stores audit events at the file `/tmp/audit.json`.

Nomad's documentation is a little vague but implies the prior behavior
of always appending a timestamp.
