### PR TITLE
fix (encrypt): Support slice of taggable values

### DIFF
--- a/filters/encrypt/CHANGELOG.md
+++ b/filters/encrypt/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next 
 ### New and Improved
+- Fix: Support slice of taggable values.
+  ([PR](https://github.com/hashicorp/go-eventlogger/pull/66)) 
 - Filter map fields which are not tagged. ([PR](https://github.com/hashicorp/go-eventlogger/pull/63))
 - Setting filters to no operation. ([PR](https://github.com/hashicorp/go-eventlogger/pull/61))
 

--- a/filters/encrypt/testing.go
+++ b/filters/encrypt/testing.go
@@ -75,6 +75,8 @@ func TestHmacSha256(t *testing.T, data []byte, w wrapping.Wrapper, salt, info []
 // TestMapField defines a const for a field name used for testing TestTaggedMap
 const TestMapField = "foo"
 
+const TestPublicMapField = "public-foo"
+
 // TestTaggedMap is a map that implements the Taggable interface for testing
 type TestTaggedMap map[string]interface{}
 
@@ -85,6 +87,11 @@ func (t TestTaggedMap) Tags() ([]PointerTag, error) {
 			Pointer:        "/" + TestMapField,
 			Classification: SecretClassification,
 			Filter:         RedactOperation,
+		},
+		{
+			Pointer:        "/" + TestPublicMapField,
+			Classification: PublicClassification,
+			Filter:         NoOperation,
 		},
 	}, nil
 }


### PR DESCRIPTION
When a slice contains values which implement the Taggable interface,
we will filter those items based on the values of its Taggable.Tags().

Prior to this fix, we were not checking to see if the items in
a slice had implemented the Taggable interface.