### PR TITLE
refactor: Change delimiters for REDACTED data

### DIFF
--- a/filters/encrypt/CHANGELOG.md
+++ b/filters/encrypt/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next 
 
+- Refactor:  Change delimiters for REDACTED data 
+  ([PR](https://github.com/hashicorp/go-eventlogger/pull/74))
+
+##  filters/encrypt/v0.1.5 (2021/10/26)
+
 - Feature: Add support to ignore types when filtering 
   ([PR](https://github.com/hashicorp/go-eventlogger/pull/72))
 - Fix: Correct the prefix used for hmac-sha256 filtered data

--- a/filters/encrypt/classification.go
+++ b/filters/encrypt/classification.go
@@ -2,7 +2,7 @@ package encrypt
 
 const (
 	// RedactedData is the value that replaces redacted data (secrets)
-	RedactedData = "<REDACTED>"
+	RedactedData = "[REDACTED]"
 
 	// DataClassificationTagName is the tag name for classifying data into
 	// DataClassification's

--- a/filters/encrypt/docs_test.go
+++ b/filters/encrypt/docs_test.go
@@ -84,7 +84,7 @@ func ExampleFilter() {
 	}
 
 	// Output:
-	// {"created_at":"2009-11-17T20:34:58.651387237Z","event_type":"test-event","payload":{"NoClassification":"no classification","Public":"public","Sensitive":"sensitive","Secret":"secret","TaggableMap":{"no-classification":"\u003cREDACTED\u003e","public":"public","secret":"\u003cREDACTED\u003e","sensitive":"\u003cREDACTED\u003e"}}}
+	// {"created_at":"2009-11-17T20:34:58.651387237Z","event_type":"test-event","payload":{"NoClassification":"no classification","Public":"public","Sensitive":"sensitive","Secret":"secret","TaggableMap":{"no-classification":"[REDACTED]","public":"public","secret":"[REDACTED]","sensitive":"[REDACTED]"}}}
 }
 
 const (

--- a/filters/encrypt/filter_test_pkg_test.go
+++ b/filters/encrypt/filter_test_pkg_test.go
@@ -300,7 +300,7 @@ func TestFilter_Process(t *testing.T) {
 				Type:      "test",
 				CreatedAt: now,
 				Payload: &encrypt.TestTaggedMap{
-					encrypt.TestMapField: "<REDACTED>",
+					encrypt.TestMapField: encrypt.RedactedData,
 				},
 			},
 		},
@@ -318,7 +318,7 @@ func TestFilter_Process(t *testing.T) {
 				Type:      "test",
 				CreatedAt: now,
 				Payload: encrypt.TestTaggedMap{
-					encrypt.TestMapField: "<REDACTED>",
+					encrypt.TestMapField: encrypt.RedactedData,
 				},
 			},
 		},
@@ -343,7 +343,7 @@ func TestFilter_Process(t *testing.T) {
 					PublicId:          "id-12",
 					SensitiveUserName: "Alice Eve Doe",
 					TaggedMap: encrypt.TestTaggedMap{
-						encrypt.TestMapField: "<REDACTED>",
+						encrypt.TestMapField: encrypt.RedactedData,
 					},
 				},
 			},
@@ -376,7 +376,7 @@ func TestFilter_Process(t *testing.T) {
 					SensitiveUserName: "Alice Eve Doe",
 					TaggedMap: []*encrypt.TestTaggedMap{
 						{
-							encrypt.TestMapField:       "<REDACTED>",
+							encrypt.TestMapField:       encrypt.RedactedData,
 							encrypt.TestPublicMapField: "public-bar",
 						},
 					},
@@ -405,7 +405,7 @@ func TestFilter_Process(t *testing.T) {
 				CreatedAt: now,
 				Payload: []encrypt.TestTaggedMap{
 					{
-						encrypt.TestMapField:       "<REDACTED>",
+						encrypt.TestMapField:       encrypt.RedactedData,
 						encrypt.TestPublicMapField: "public-bar",
 					},
 				},


### PR DESCRIPTION
The existing delimiters of <> created some encoding challenges, since
the Go json encoder escapes them into safe html characters.  Moving to
[] for delimiters just removes the problem.