### PR TITLE
Use sync.Map for graph roots map

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -153,7 +153,7 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 
 	g, ok := b.graphs[def.EventType]
 	if !ok {
-		g = &graph{roots: make(map[PipelineID]*linkedNode)}
+		g = &graph{}
 		b.graphs[def.EventType] = g
 	}
 
@@ -175,7 +175,7 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 		return err
 	}
 
-	g.roots[def.PipelineID] = root
+	g.roots.Store(def.PipelineID, root)
 
 	return nil
 }
@@ -190,7 +190,7 @@ func (b *Broker) RemovePipeline(t EventType, id PipelineID) error {
 		return fmt.Errorf("No graph for EventType %s", t)
 	}
 
-	delete(g.roots, id)
+	g.roots.Delete(id)
 	return nil
 }
 
@@ -207,7 +207,7 @@ func (b *Broker) SetSuccessThreshold(t EventType, successThreshold int) error {
 
 	g, ok := b.graphs[t]
 	if !ok {
-		g = &graph{roots: make(map[PipelineID]*linkedNode)}
+		g = &graph{}
 		b.graphs[t] = g
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
+	github.com/hashicorp/go-uuid v1.0.2
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/graph_test.go
+++ b/graph_test.go
@@ -38,11 +38,8 @@ func TestReopen(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := graph{
-		roots: map[PipelineID]*linkedNode{
-			"id": root,
-		},
-	}
+	g := graph{}
+	g.roots.Store("id", root)
 	err = g.reopen(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -120,11 +117,8 @@ func TestValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			g := graph{
-				roots: map[PipelineID]*linkedNode{
-					"id": root,
-				},
-			}
+			g := graph{}
+			g.roots.Store("id", root)
 			err = g.validate()
 			valid := err == nil
 			if valid != tc.valid {
@@ -215,12 +209,8 @@ func TestSendResult(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			g := graph{
-				roots: map[PipelineID]*linkedNode{
-					"id": root,
-				},
-				successThreshold: tc.threshold,
-			}
+			g := graph{successThreshold: tc.threshold}
+			g.roots.Store("id", root)
 
 			err = g.validate()
 			if err != nil {
@@ -344,12 +334,8 @@ func TestSendBlocking(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			g := graph{
-				roots: map[PipelineID]*linkedNode{
-					"id": root,
-				},
-				successThreshold: tc.threshold,
-			}
+			g := graph{successThreshold: tc.threshold}
+			g.roots.Store("id", root)
 
 			err = g.validate()
 			if err != nil {

--- a/graphmap.go
+++ b/graphmap.go
@@ -1,0 +1,27 @@
+package eventlogger
+
+import "sync"
+
+// TODO: remove this if Go ever introduces sync.Map with generics
+
+// graphMap implements a type-safe synchronized map[PipelineID]*linkedNode
+type graphMap struct {
+	m sync.Map
+}
+
+// Range calls sync.Map.Range
+func (g *graphMap) Range(f func(key PipelineID, value *linkedNode) bool) {
+	g.m.Range(func(key, value interface{}) bool {
+		return f(key.(PipelineID), value.(*linkedNode))
+	})
+}
+
+// Store calls sync.Map.Store
+func (g *graphMap) Store(id PipelineID, root *linkedNode) {
+	g.m.Store(id, root)
+}
+
+// Delete calls sync.Map.Delete
+func (g *graphMap) Delete(id PipelineID) {
+	g.m.Delete(id)
+}


### PR DESCRIPTION
I ran into a race condition related to the `graph.roots` map, e.g.,

https://app.circleci.com/pipelines/github/hashicorp/vault/50560/workflows/96d003c2-185e-4504-a4c0-fab481ed6282/jobs/594936

happens when registering and removing a pipeline (which accesses a `graph`'s `roots` map) when another goroutine is iterating through the map in, for example, `graph.process()`. The pipeline registering and removing are protected by the broker's lock, but the `graph.process()` is *not* protected by the lock (since it does not have access to it).

Adding another lock for `graph.roots` might be messy and lead to deadlock possibilities, so I thought the easiest way to resolve this was to switch to a `sync.Map`.

I confirmed that this change fixes the above race condition in Vault's tests.