### PR TITLE
Updated linkNodes to include the nodeID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+.idea/

--- a/node.go
+++ b/node.go
@@ -44,7 +44,7 @@ func linkNodes(nodes []Node, ids []NodeID) (*linkedNode, error) {
 	case len(nodes) == 0:
 		return nil, fmt.Errorf("no nodes given")
 	case len(ids) == 0:
-		return nil, fmt.Errorf("no ids given")
+		return nil, fmt.Errorf("no IDs given")
 	case len(nodes) != len(ids):
 		return nil, fmt.Errorf("number of nodes does not match number of IDs")
 	}

--- a/node.go
+++ b/node.go
@@ -38,18 +38,20 @@ type linkedNode struct {
 	next   []*linkedNode
 }
 
-// linkNodes is a convenience function that connects Nodes together into a
-// linked list.
+// linkNodes is a convenience function that connects Nodes together into a linked list.
 func linkNodes(nodes []Node, ids []NodeID) (*linkedNode, error) {
 	if len(nodes) == 0 {
 		return nil, fmt.Errorf("no nodes given")
 	}
+	if len(nodes) != len(ids) {
+		return nil, fmt.Errorf("number of nodes does not match number of IDs")
+	}
 
-	root := &linkedNode{node: nodes[0]}
+	root := &linkedNode{node: nodes[0], nodeID: ids[0]}
 	cur := root
 
-	for _, n := range nodes[1:] {
-		next := &linkedNode{node: n}
+	for i, n := range nodes[1:] {
+		next := &linkedNode{node: n, nodeID: ids[i+1]}
 		cur.next = []*linkedNode{next}
 		cur = next
 	}

--- a/node.go
+++ b/node.go
@@ -40,10 +40,12 @@ type linkedNode struct {
 
 // linkNodes is a convenience function that connects Nodes together into a linked list.
 func linkNodes(nodes []Node, ids []NodeID) (*linkedNode, error) {
-	if len(nodes) == 0 {
+	switch {
+	case len(nodes) == 0:
 		return nil, fmt.Errorf("no nodes given")
-	}
-	if len(nodes) != len(ids) {
+	case len(ids) == 0:
+		return nil, fmt.Errorf("no ids given")
+	case len(nodes) != len(ids):
 		return nil, fmt.Errorf("number of nodes does not match number of IDs")
 	}
 

--- a/node_test.go
+++ b/node_test.go
@@ -41,6 +41,8 @@ func TestLinkNodes(t *testing.T) {
 	}
 }
 
+// TestLinkNodesErrors attempts to exercise the linkNodes func such that we hit
+// the early return error checking on the incoming parameters.
 func TestLinkNodesErrors(t *testing.T) {
 	tests := map[string]struct {
 		nodes            []Node

--- a/node_test.go
+++ b/node_test.go
@@ -62,14 +62,14 @@ func TestLinkNodesErrors(t *testing.T) {
 				&Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"},
 			},
 			ids:              nil,
-			wantErrorMessage: "no ids given",
+			wantErrorMessage: "no IDs given",
 		},
 		"no-ids": {
 			nodes: []Node{
 				&Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"},
 			},
 			ids:              []NodeID{},
-			wantErrorMessage: "no ids given",
+			wantErrorMessage: "no IDs given",
 		},
 		"more-nodes-than-ids": {
 			nodes: []Node{

--- a/node_test.go
+++ b/node_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/go-test/deep"
 )
 
+// TestLinkNodes ensures that we are able to create a graph of linked nodes correctly.
+// NOTE: This test should not be run in parallel as it sets a package level variable
+// on 'deep' to ensure we compare unexported fields too.
 func TestLinkNodes(t *testing.T) {
 	n1, n2, n3 := &Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"}
 	root, err := linkNodes([]Node{n1, n2, n3}, []NodeID{"1", "2", "3"})
@@ -28,6 +31,9 @@ func TestLinkNodes(t *testing.T) {
 			}},
 		}},
 	}
+
+	deep.CompareUnexportedFields = true
+	t.Cleanup(func() { deep.CompareUnexportedFields = false })
 
 	if diff := deep.Equal(root, expected); len(diff) > 0 {
 		t.Fatal(diff)


### PR DESCRIPTION
`linkNodes` doesn't link the `node` to the `nodeID`, which does happen for sinks under `linkNodesAndSinks`, this change makes them behave in the same way.