### PR TITLE
tests: explicitly test success thresholds with filtered events

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -66,17 +66,19 @@ func (b *Broker) StopTimeAt(now time.Time) {
 
 // Status describes the result of a Send.
 type Status struct {
-	// complete lists the IDs of sinks that successfully wrote the Event.
+	// complete lists the IDs of 'filter' and 'sink' type nodes that successfully processed the Event.
 	complete []NodeID
 	// Warnings lists any non-fatal errors that occurred while sending an Event.
 	Warnings []error
 }
 
 func (s Status) getError(threshold int) error {
-	if len(s.complete) < threshold {
-		return fmt.Errorf("event not written to enough sinks")
+	switch {
+	case len(s.complete) < threshold:
+		return fmt.Errorf("event not processed by enough 'filter' and 'sink' nodes")
+	default:
+		return nil
 	}
-	return nil
 }
 
 // Send writes an event of type t to all registered pipelines concurrently and

--- a/graph.go
+++ b/graph.go
@@ -55,6 +55,15 @@ func (g *graph) process(ctx context.Context, e *Event) (Status, error) {
 }
 
 // Recursively process every node in the graph.
+//
+// # No Status is sent when a request is cancelled by the context
+//
+// Status will be sent when we stop processing nodes, which can happen if:
+//   - a node.Process(...) returns an error, and Status.complete is empty
+//   - a node.Process(...) filters an event, and Status.complete contains the
+//     filter node's ID
+//   - the final node in a pipeline (a sink) finishes, and Status.complete contains
+//     the sink node's ID
 func (g *graph) doProcess(ctx context.Context, node *linkedNode, e *Event, statusChan chan Status, wg *sync.WaitGroup) {
 	defer wg.Done()
 


### PR DESCRIPTION
Note: we need to rebase this once [#86](https://github.com/hashicorp/go-eventlogger/pull/86) has been merged.