### PR TITLE
Unregister nodes along with pipeline

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -225,7 +225,7 @@ func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
 
 	nodes, err := g.roots.Nodes(id)
 	if err != nil {
-		// TODO: error getting flattened nodes for our pipeline.
+		return fmt.Errorf("unable to retrieve all nodes referenced by pipeline ID %q: %w", id, err)
 	}
 
 	err = b.RemovePipeline(t, id)

--- a/broker.go
+++ b/broker.go
@@ -86,16 +86,16 @@ func getOpts(opt ...Option) options {
 }
 
 // WithPipelineRegistrationPolicy configures the option that determines the pipeline registration policy.
-func WithPipelineRegistrationPolicy(mode RegistrationPolicy) Option {
+func WithPipelineRegistrationPolicy(policy RegistrationPolicy) Option {
 	return func(o *options) {
-		o.withPipelineRegistrationPolicy = mode
+		o.withPipelineRegistrationPolicy = policy
 	}
 }
 
 // WithNodeRegistrationPolicy configures the option that determines the node registration policy.
-func WithNodeRegistrationPolicy(mode RegistrationPolicy) Option {
+func WithNodeRegistrationPolicy(policy RegistrationPolicy) Option {
 	return func(o *options) {
-		o.withNodeRegistrationPolicy = mode
+		o.withNodeRegistrationPolicy = policy
 	}
 }
 

--- a/broker.go
+++ b/broker.go
@@ -75,6 +75,8 @@ func getDefaultOptions() options {
 }
 
 // getOpts iterates the inbound Options and returns a struct.
+// Each Option is applied in the order it appears in the argument list, so it is
+// possible to supply the same Option numerous times and the 'last write wins'.
 func getOpts(opt ...Option) options {
 	opts := getDefaultOptions()
 	for _, o := range opt {

--- a/broker.go
+++ b/broker.go
@@ -178,7 +178,7 @@ type Pipeline struct {
 
 // RegisterPipeline adds a pipeline to the broker.
 func (b *Broker) RegisterPipeline(def Pipeline) error {
-	ok, err := def.validate()
+	err := def.validate()
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func (b *Broker) SetSuccessThresholdSinks(t EventType, successThresholdSinks int
 
 // validate ensures that the Pipeline has the required configuration to allow
 // registration, removal or usage, without issue.
-func (p Pipeline) validate() (bool, error) {
+func (p Pipeline) validate() error {
 	var err error
 
 	if p.PipelineID == "" {
@@ -365,5 +365,5 @@ func (p Pipeline) validate() (bool, error) {
 		}
 	}
 
-	return err == nil, err
+	return err
 }

--- a/broker.go
+++ b/broker.go
@@ -239,14 +239,14 @@ func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
 
 	err = b.RemovePipeline(t, id)
 	if err != nil {
-		// Error removing the actual pipeline, so probably a good idea to leave the node registrations alone..
-		return fmt.Errorf("unable to remove pipeline ID: %q and linked nodes: %w", err)
+		// Don't continue and delete nodes if we cannot remove the pipeline.
+		return fmt.Errorf("unable to remove pipeline ID %q and linked nodes: %w", id, err)
 	}
 
 	for _, nodeID := range nodes {
 		instance, ok := b.nodes[nodeID]
 		if !ok {
-			return fmt.Errorf("pipeline ID: %q, node ID %q is not registered", id, nodeID)
+			return fmt.Errorf("pipeline ID %q: node ID %q is not registered", id, nodeID)
 		}
 
 		switch instance.usages {

--- a/broker.go
+++ b/broker.go
@@ -271,10 +271,14 @@ func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
 
 	g.roots.Delete(id)
 
+	var nodeErr error
+
 	for _, nodeID := range nodes {
 		nodeUsage, ok := b.nodes[nodeID]
 		if !ok {
-			return fmt.Errorf("pipeline ID %q: node ID %q is not registered", id, nodeID)
+			// We might get multiple nodes which cannot be found
+			nodeErr = multierror.Append(nodeErr, fmt.Errorf("node not found: %q", nodeID))
+			continue
 		}
 
 		switch nodeUsage.referenceCount {
@@ -286,7 +290,7 @@ func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
 		}
 	}
 
-	return nil
+	return nodeErr
 }
 
 // SetSuccessThreshold sets the success threshold per eventType.  For the

--- a/broker.go
+++ b/broker.go
@@ -324,10 +324,10 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 
 // RemovePipeline removes a pipeline from the broker.
 func (b *Broker) RemovePipeline(t EventType, id PipelineID) error {
-	if t == "" {
+	switch {
+	case t == "":
 		return errors.New("event type cannot be empty")
-	}
-	if id == "" {
+	case id == "":
 		return errors.New("pipeline ID cannot be empty")
 	}
 
@@ -346,10 +346,10 @@ func (b *Broker) RemovePipeline(t EventType, id PipelineID) error {
 // RemovePipelineAndNodes will attempt to remove all nodes referenced by the pipeline.
 // Any nodes that are referenced by other pipelines will not be removed.
 func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
-	if t == "" {
+	switch {
+	case t == "":
 		return errors.New("event type cannot be empty")
-	}
-	if id == "" {
+	case id == "":
 		return errors.New("pipeline ID cannot be empty")
 	}
 
@@ -398,10 +398,10 @@ func (b *Broker) RemovePipelineAndNodes(t EventType, id PipelineID) error {
 // meeting this threshold.  Use this when you want to allow the filtering of
 // events without causing an error because an event was filtered.
 func (b *Broker) SetSuccessThreshold(t EventType, successThreshold int) error {
-	if t == "" {
+	switch {
+	case t == "":
 		return errors.New("event type cannot be empty")
-	}
-	if successThreshold < 0 {
+	case successThreshold < 0:
 		return fmt.Errorf("successThreshold must be 0 or greater")
 	}
 
@@ -422,10 +422,10 @@ func (b *Broker) SetSuccessThreshold(t EventType, successThreshold int) error {
 // overall processing of a given event to be considered a success, at least as
 // many sinks as the threshold value must successfully process the event.
 func (b *Broker) SetSuccessThresholdSinks(t EventType, successThresholdSinks int) error {
-	if t == "" {
+	switch {
+	case t == "":
 		return errors.New("event type cannot be empty")
-	}
-	if successThresholdSinks < 0 {
+	case successThresholdSinks < 0:
 		return fmt.Errorf("successThresholdSinks must be 0 or greater")
 	}
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -511,14 +511,12 @@ func TestPipelineValidate(t *testing.T) {
 				NodeIDs:    tc.nodes,
 			}
 
-			valid, err := p.validate()
+			err := p.validate()
 			switch tc.expectValid {
 			case true:
 				require.NoError(t, err)
-				require.True(t, valid)
 			default:
 				require.Error(t, err)
-				require.False(t, valid)
 				me, ok := err.(*multierror.Error)
 				require.True(t, ok)
 				require.Equal(t, tc.expectErrorCount, me.Len())

--- a/broker_test.go
+++ b/broker_test.go
@@ -413,7 +413,7 @@ func TestRemovePipelineAndNodes(t *testing.T) {
 		NodeIDs:    nodeIDs,
 	})
 	require.Error(t, err)
-	require.EqualError(t, err, "nodeID \"node-0\" not registered")
+	require.EqualError(t, err, "node ID \"node-0\" not registered")
 
 	// Re-register nodes and 2 pipelines which use the same nodes
 	nodeIDs = nodesToNodeIDs(t, broker, f1, s1)
@@ -443,7 +443,6 @@ func TestRemovePipelineAndNodes(t *testing.T) {
 	require.Error(t, err)
 	me, ok := err.(*multierror.Error)
 	require.True(t, ok)
-	require.EqualError(t, me.Unwrap(), "node not found: \"node-0\"")
 	require.Equal(t, 2, me.Len())
 }
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -380,6 +380,8 @@ func TestSuccessThresholdSinks(t *testing.T) {
 	}
 }
 
+// TestRemovePipelineAndNodes exercises the behavior that removes a pipeline and
+// any nodes associated with that pipeline, if they are not referenced by other pipelines.
 func TestRemovePipelineAndNodes(t *testing.T) {
 	broker := NewBroker()
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -443,6 +443,13 @@ func TestRemovePipelineAndNodes(t *testing.T) {
 	require.NotEmpty(t, broker.nodes)
 	require.Equal(t, 2, len(broker.nodes))
 
+	// Attempt to deregister a pipeline with the wrong event type
+	err = broker.RemovePipelineAndNodes(EventType("foo"), PipelineID("p2"))
+	require.Error(t, err)
+	require.EqualError(t, err, "no graph for EventType foo")
+	require.NotEmpty(t, broker.nodes)
+	require.Equal(t, 2, len(broker.nodes))
+
 	// Whip the nodes out from underneath a pipeline and then try to deregister it
 	broker.nodes = nil
 	err = broker.RemovePipelineAndNodes(EventType("t"), "p2")

--- a/broker_test.go
+++ b/broker_test.go
@@ -563,6 +563,15 @@ func TestPipelineValidate(t *testing.T) {
 	}
 }
 
+// TestRegisterNode_NoID ensures we cannot register a Node with an empty ID.
+func TestRegisterNode_NoID(t *testing.T) {
+	b, err := NewBroker()
+	require.NoError(t, err)
+	err = b.RegisterNode("", &JSONFormatter{})
+	require.Error(t, err)
+	require.EqualError(t, err, "unable to register node, node ID cannot be empty")
+}
+
 // TestBroker_RegisterNode_AllowOverwrite_Implicit is used to prove that nodes can be
 // overwritten when a Broker has been implicitly configured with the AllowOverwrite policy.
 // This is the default in order to maintain pre-existing behavior.

--- a/broker_test.go
+++ b/broker_test.go
@@ -448,6 +448,15 @@ func TestRemovePipelineAndNodes(t *testing.T) {
 	err = broker.RemovePipelineAndNodes(EventType("t"), PipelineID(""))
 	require.Error(t, err)
 	require.EqualError(t, err, "pipeline ID cannot be empty")
+
+	// Whip the nodes out from underneath a pipeline and then try to deregister it
+	broker.nodes = nil
+	err = broker.RemovePipelineAndNodes(EventType("t"), "p2")
+	require.Error(t, err)
+	me, ok := err.(*multierror.Error)
+	require.True(t, ok)
+	require.EqualError(t, me.Unwrap(), "node not found: \"node-0\"")
+	require.Equal(t, 2, me.Len())
 }
 
 // TestPipelineValidate tests that given a Pipeline in various states we can assert

--- a/broker_test.go
+++ b/broker_test.go
@@ -51,7 +51,8 @@ func TestBroker(t *testing.T) {
 	}
 
 	// Create a broker
-	broker := NewBroker()
+	broker, err := NewBroker()
+	require.NoError(t, err)
 	now := time.Now()
 	broker.clock = &clock{now}
 
@@ -148,11 +149,12 @@ func TestBroker(t *testing.T) {
 }
 
 func TestPipeline(t *testing.T) {
-	broker := NewBroker()
+	broker, err := NewBroker()
+	require.NoError(t, err)
 
 	// invalid pipeline
 	nodeIDs := nodesToNodeIDs(t, broker, &Filter{Predicate: nil})
-	err := broker.RegisterPipeline(Pipeline{
+	err = broker.RegisterPipeline(Pipeline{
 		EventType:  "t",
 		PipelineID: "id",
 		NodeIDs:    nodeIDs,
@@ -257,7 +259,8 @@ func TestPipeline(t *testing.T) {
 
 // TestPipelineRaceCondition can't fail, but it can check if there is a race condition in iterating through, adding, or removing pipelines.
 func TestPipelineRaceCondition(t *testing.T) {
-	broker := NewBroker()
+	broker, err := NewBroker()
+	require.NoError(t, err)
 
 	eventType := EventType("t")
 	var pipelines []PipelineID
@@ -340,9 +343,10 @@ func (ts *testSink) Name() string {
 }
 
 func TestSuccessThreshold(t *testing.T) {
-	b := NewBroker()
+	b, err := NewBroker()
+	require.NoError(t, err)
 
-	err := b.SetSuccessThreshold("t", 2)
+	err = b.SetSuccessThreshold("t", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,9 +365,10 @@ func TestSuccessThreshold(t *testing.T) {
 }
 
 func TestSuccessThresholdSinks(t *testing.T) {
-	b := NewBroker()
+	b, err := NewBroker()
+	require.NoError(t, err)
 
-	err := b.SetSuccessThresholdSinks("t", 2)
+	err = b.SetSuccessThresholdSinks("t", 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +391,8 @@ func TestSuccessThresholdSinks(t *testing.T) {
 // The test is relatively long as it is focused on the state of the broker across
 // multiple operations.
 func TestRemovePipelineAndNodes(t *testing.T) {
-	broker := NewBroker()
+	broker, err := NewBroker()
+	require.NoError(t, err)
 
 	// Construct a graph
 	f1 := &JSONFormatter{}
@@ -394,7 +400,7 @@ func TestRemovePipelineAndNodes(t *testing.T) {
 	nodeIDs := nodesToNodeIDs(t, broker, f1, s1)
 
 	// Register single pipeline
-	err := broker.RegisterPipeline(Pipeline{
+	err = broker.RegisterPipeline(Pipeline{
 		EventType:  "t",
 		PipelineID: "p1",
 		NodeIDs:    nodeIDs,
@@ -473,8 +479,9 @@ func TestRemovePipelineAndNodes_BadParameters(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			broker := NewBroker()
-			err := broker.RemovePipelineAndNodes(EventType(tc.eventType), PipelineID(tc.pipelineID))
+			broker, err := NewBroker()
+			require.NoError(t, err)
+			err = broker.RemovePipelineAndNodes(EventType(tc.eventType), PipelineID(tc.pipelineID))
 			require.Error(t, err)
 			require.EqualError(t, err, tc.error)
 		})
@@ -560,8 +567,9 @@ func TestPipelineValidate(t *testing.T) {
 // overwritten when a Broker has been implicitly configured with the AllowOverwrite policy.
 // This is the default in order to maintain pre-existing behavior.
 func TestBroker_RegisterNode_AllowOverwrite_Implicit(t *testing.T) {
-	b := NewBroker()
-	err := b.RegisterNode("n1", &JSONFormatter{})
+	b, err := NewBroker()
+	require.NoError(t, err)
+	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &FileSink{})
 	require.NoError(t, err)
@@ -570,8 +578,9 @@ func TestBroker_RegisterNode_AllowOverwrite_Implicit(t *testing.T) {
 // TestBroker_RegisterNode_AllowOverwrite_Explicit is used to prove that nodes can be
 // overwritten when a Broker has been explicitly configured with the AllowOverwrite policy.
 func TestBroker_RegisterNode_AllowOverwrite_Explicit(t *testing.T) {
-	b := NewBroker(WithNodeRegistrationPolicy(AllowOverwrite))
-	err := b.RegisterNode("n1", &JSONFormatter{})
+	b, err := NewBroker(WithNodeRegistrationPolicy(AllowOverwrite))
+	require.NoError(t, err)
+	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &FileSink{})
 	require.NoError(t, err)
@@ -580,8 +589,9 @@ func TestBroker_RegisterNode_AllowOverwrite_Explicit(t *testing.T) {
 // TestBroker_RegisterNode_DenyOverwrite is used to prove that nodes can't be
 // overwritten when a Broker has been configured with the DenyOverwrite policy.
 func TestBroker_RegisterNode_DenyOverwrite(t *testing.T) {
-	b := NewBroker(WithNodeRegistrationPolicy(DenyOverwrite))
-	err := b.RegisterNode("n1", &JSONFormatter{})
+	b, err := NewBroker(WithNodeRegistrationPolicy(DenyOverwrite))
+	require.NoError(t, err)
+	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &FileSink{})
 	require.Error(t, err)
@@ -592,9 +602,10 @@ func TestBroker_RegisterNode_DenyOverwrite(t *testing.T) {
 // overwritten when a Broker has been implicitly configured with the AllowOverwrite policy.
 // This is the default in order to maintain pre-existing behavior.
 func TestBroker_RegisterPipeline_AllowOverwrite_Implicit(t *testing.T) {
-	b := NewBroker()
+	b, err := NewBroker()
+	require.NoError(t, err)
 
-	err := b.RegisterNode("f1", &JSONFormatter{})
+	err = b.RegisterNode("f1", &JSONFormatter{})
 	require.NoError(t, err)
 
 	err = b.RegisterNode("f2", &JSONFormatter{})
@@ -621,9 +632,10 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Implicit(t *testing.T) {
 // TestBroker_RegisterPipeline_AllowOverwrite_Explicit is used to prove that pipelines can be
 // overwritten when a Broker has been explicitly configured with the AllowOverwrite policy.
 func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
-	b := NewBroker(WithPipelineRegistrationPolicy(AllowOverwrite))
+	b, err := NewBroker(WithPipelineRegistrationPolicy(AllowOverwrite))
+	require.NoError(t, err)
 
-	err := b.RegisterNode("f1", &JSONFormatter{})
+	err = b.RegisterNode("f1", &JSONFormatter{})
 	require.NoError(t, err)
 
 	err = b.RegisterNode("f2", &JSONFormatter{})
@@ -650,9 +662,10 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
 // TestBroker_RegisterPipeline_DenyOverwrite is used to prove that pipelines can't
 // // be overwritten when a Broker has been configured with the DenyOverwrite policy.
 func TestBroker_RegisterPipeline_DenyOverwrite(t *testing.T) {
-	b := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	b, err := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	require.NoError(t, err)
 
-	err := b.RegisterNode("f1", &JSONFormatter{})
+	err = b.RegisterNode("f1", &JSONFormatter{})
 	require.NoError(t, err)
 
 	err = b.RegisterNode("f2", &JSONFormatter{})

--- a/filters/gated/docs_test.go
+++ b/filters/gated/docs_test.go
@@ -18,7 +18,7 @@ func ExampleFilter() {
 	then := time.Date(
 		2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 	// Create a broker
-	b := eventlogger.NewBroker()
+	b, _ := eventlogger.NewBroker()
 
 	b.StopTimeAt(then) // setting this so the output timestamps are predictable for testing.
 

--- a/filters/gated/gated_test.go
+++ b/filters/gated/gated_test.go
@@ -484,7 +484,8 @@ func testBrokerWithGatedFilter(t *testing.T, testName string, eventType string) 
 	})
 
 	// Create a broker
-	b := eventlogger.NewBroker()
+	b, err := eventlogger.NewBroker()
+	require.NoError(err)
 
 	gf := &gated.Filter{
 		Broker: b,

--- a/formatter_filters/cloudevents/docs_test.go
+++ b/formatter_filters/cloudevents/docs_test.go
@@ -19,7 +19,7 @@ func ExampleFormatter() {
 	then := time.Date(
 		2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 	// Create a broker
-	b := eventlogger.NewBroker()
+	b, _ := eventlogger.NewBroker()
 
 	b.StopTimeAt(then) // setting this so the output timestamps are predictable for testing.
 

--- a/graphmap.go
+++ b/graphmap.go
@@ -3,7 +3,10 @@
 
 package eventlogger
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // TODO: remove this if Go ever introduces sync.Map with generics
 
@@ -27,4 +30,23 @@ func (g *graphMap) Store(id PipelineID, root *linkedNode) {
 // Delete calls sync.Map.Delete
 func (g *graphMap) Delete(id PipelineID) {
 	g.m.Delete(id)
+}
+
+// Nodes returns all the nodes referenced by the specified Pipeline
+func (g *graphMap) Nodes(id PipelineID) ([]NodeID, error) {
+	root, ok := g.m.Load(id)
+	if !ok {
+		return nil, fmt.Errorf("unable to load root node from underlying data store")
+	}
+
+	ln, ok := root.(*linkedNode)
+	if !ok {
+		return nil, fmt.Errorf("unable to retrieve linked nodes from underyling data store")
+	}
+	nodes := ln.flatten(nil)
+	result := make([]NodeID, len(nodes))
+	for k := range nodes {
+		result = append(result, k)
+	}
+	return result, nil
 }

--- a/graphmap.go
+++ b/graphmap.go
@@ -45,8 +45,10 @@ func (g *graphMap) Nodes(id PipelineID) ([]NodeID, error) {
 	}
 	nodes := ln.flatten(nil)
 	result := make([]NodeID, len(nodes))
+	i := 0
 	for k := range nodes {
-		result = append(result, k)
+		result[i] = k
+		i++
 	}
 	return result, nil
 }

--- a/graphmap.go
+++ b/graphmap.go
@@ -41,7 +41,7 @@ func (g *graphMap) Nodes(id PipelineID) ([]NodeID, error) {
 
 	ln, ok := root.(*linkedNode)
 	if !ok {
-		return nil, fmt.Errorf("unable to retrieve linked nodes from underyling data store")
+		return nil, fmt.Errorf("unable to retrieve linked nodes from underlying data store")
 	}
 	nodes := ln.flatten(nil)
 	result := make([]NodeID, len(nodes))

--- a/graphmap_test.go
+++ b/graphmap_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// TestNodes_ListNodes_UnregisteredPipeline checks that we get the right error
+// when attempting to get the linked nodes for an unregistered pipeline.
 func TestNodes_ListNodes_UnregisteredPipeline(t *testing.T) {
 	g := &graphMap{}
 	ids, err := g.Nodes(PipelineID("31"))
@@ -13,6 +15,8 @@ func TestNodes_ListNodes_UnregisteredPipeline(t *testing.T) {
 	require.Nil(t, ids)
 }
 
+// TestNodes_ListNodes_RegisteredPipeline checks that we can retrieve all registered
+// nodes referenced by a registered pipeline.
 func TestNodes_ListNodes_RegisteredPipeline(t *testing.T) {
 	g := &graphMap{}
 

--- a/graphmap_test.go
+++ b/graphmap_test.go
@@ -1,0 +1,35 @@
+package eventlogger
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNodes_ListNodes_UnregisteredPipeline(t *testing.T) {
+	g := &graphMap{}
+	ids, err := g.Nodes(PipelineID("31"))
+	require.Error(t, err)
+	require.EqualError(t, err, "unable to load root node from underlying data store")
+	require.Nil(t, ids)
+}
+
+func TestNodes_ListNodes_RegisteredPipeline(t *testing.T) {
+	g := &graphMap{}
+
+	// Create some nodes
+	ids := []NodeID{"a", "b", "c"}
+	nodes := []Node{
+		&Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"},
+	}
+
+	linkedNodes, err := linkNodes(nodes, ids)
+	require.NoError(t, err)
+
+	g.Store(PipelineID("1"), linkedNodes)
+	nodeIDs, err := g.Nodes(PipelineID("1"))
+	require.NoError(t, err)
+	require.NotNil(t, nodeIDs)
+	require.Contains(t, nodeIDs, NodeID("a"))
+	require.Contains(t, nodeIDs, NodeID("b"))
+	require.Contains(t, nodeIDs, NodeID("c"))
+}

--- a/node.go
+++ b/node.go
@@ -82,3 +82,24 @@ func linkNodesAndSinks(inner, sinks []Node, nodeIDs, sinkIDs []NodeID) (*linkedN
 
 	return root, nil
 }
+
+// flatten will attempt to visit every linked node and flatten the overall set of node IDs.
+func (l *linkedNode) flatten(visited map[NodeID]struct{}) map[NodeID]struct{} {
+	if visited == nil {
+		visited = map[NodeID]struct{}{}
+	}
+
+	if len(l.next) == 0 {
+		return visited
+	}
+
+	visited[l.nodeID] = struct{}{}
+
+	for _, ln := range l.next {
+		for k := range ln.flatten(visited) {
+			visited[k] = struct{}{}
+		}
+	}
+
+	return visited
+}

--- a/node.go
+++ b/node.go
@@ -83,7 +83,8 @@ func linkNodesAndSinks(inner, sinks []Node, nodeIDs, sinkIDs []NodeID) (*linkedN
 	return root, nil
 }
 
-// flatten will attempt to visit every linked node and flatten the overall set of node IDs.
+// flatten will attempt to recursively visit every linked node and flatten the overall set of node IDs.
+// flatten should be initially called by supplying a nil map of visited nodes.
 func (l *linkedNode) flatten(visited map[NodeID]struct{}) map[NodeID]struct{} {
 	if visited == nil {
 		visited = map[NodeID]struct{}{}

--- a/node.go
+++ b/node.go
@@ -89,17 +89,17 @@ func (l *linkedNode) flatten(visited map[NodeID]struct{}) map[NodeID]struct{} {
 		visited = map[NodeID]struct{}{}
 	}
 
-	if len(l.next) == 0 {
-		return visited
-	}
-
 	visited[l.nodeID] = struct{}{}
 
-	for _, ln := range l.next {
-		for k := range ln.flatten(visited) {
-			visited[k] = struct{}{}
+	switch len(l.next) {
+	case 0:
+		return visited
+	default:
+		for _, ln := range l.next {
+			for k := range ln.flatten(visited) {
+				visited[k] = struct{}{}
+			}
 		}
+		return visited
 	}
-
-	return visited
 }

--- a/node_test.go
+++ b/node_test.go
@@ -100,7 +100,7 @@ func TestLinkNodesErrors(t *testing.T) {
 
 // TestFlattenNodes tests that given a 'root' node we can correctly flatten it
 // out to retrieve the NodeIDs of linked nodes.
-func TestFlattenNodes(t *testing.T) {
+func TestFlattenNodes_LinkNodes(t *testing.T) {
 	ids := []NodeID{"1", "2", "3"}
 	nodes := []Node{
 		&Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"},
@@ -111,5 +111,30 @@ func TestFlattenNodes(t *testing.T) {
 
 	flatNodes := linkedNodes.flatten(nil)
 	require.Contains(t, flatNodes, NodeID("1"))
+	require.Contains(t, flatNodes, NodeID("2"))
+	require.Contains(t, flatNodes, NodeID("3"))
+	require.Equal(t, 3, len(flatNodes))
+}
 
+func TestFlattenNodes_LinkNodesAndSinks(t *testing.T) {
+	ids := []NodeID{"1", "2"}
+	nodes := []Node{
+		&Filter{Predicate: nil}, &JSONFormatter{},
+	}
+
+	sinkIds := []NodeID{"x", "y", "z"}
+	sinkNodes := []Node{
+		&FileSink{Path: "test.log"}, &FileSink{Path: "foo.log"}, &FileSink{Path: "bar.log"},
+	}
+
+	linkedNodes, err := linkNodesAndSinks(nodes, sinkNodes, ids, sinkIds)
+	require.NoError(t, err)
+
+	flatNodes := linkedNodes.flatten(nil)
+	require.Contains(t, flatNodes, NodeID("1"))
+	require.Contains(t, flatNodes, NodeID("2"))
+	require.Contains(t, flatNodes, NodeID("x"))
+	require.Contains(t, flatNodes, NodeID("y"))
+	require.Contains(t, flatNodes, NodeID("z"))
+	require.Equal(t, 5, len(flatNodes))
 }

--- a/node_test.go
+++ b/node_test.go
@@ -116,6 +116,8 @@ func TestFlattenNodes_LinkNodes(t *testing.T) {
 	require.Equal(t, 3, len(flatNodes))
 }
 
+// TestFlattenNodes_LinkNodesAndSinks tests that given a more complex set of linked
+// nodes we can still get the right set of registered nodes.
 func TestFlattenNodes_LinkNodesAndSinks(t *testing.T) {
 	ids := []NodeID{"1", "2"}
 	nodes := []Node{

--- a/node_test.go
+++ b/node_test.go
@@ -97,3 +97,17 @@ func TestLinkNodesErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestFlattenNodes(t *testing.T) {
+	ids := []NodeID{"1", "2", "3"}
+	nodes := []Node{
+		&Filter{Predicate: nil}, &JSONFormatter{}, &FileSink{Path: "test.log"},
+	}
+
+	linkedNodes, err := linkNodes(nodes, ids)
+	require.NoError(t, err)
+
+	flatNodes := linkedNodes.flatten(nil)
+	require.Contains(t, flatNodes, NodeID("1"))
+
+}

--- a/node_test.go
+++ b/node_test.go
@@ -98,6 +98,8 @@ func TestLinkNodesErrors(t *testing.T) {
 	}
 }
 
+// TestFlattenNodes tests that given a 'root' node we can correctly flatten it
+// out to retrieve the NodeIDs of linked nodes.
 func TestFlattenNodes(t *testing.T) {
 	ids := []NodeID{"1", "2", "3"}
 	nodes := []Node{

--- a/sinks/writer/docs_test.go
+++ b/sinks/writer/docs_test.go
@@ -17,7 +17,7 @@ func ExampleSink() {
 	then := time.Date(
 		2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
 	// Create a broker
-	b := eventlogger.NewBroker()
+	b, _ := eventlogger.NewBroker()
 
 	b.StopTimeAt(then) // setting this so the output timestamps are predictable for testing.
 


### PR DESCRIPTION
This PR adds the ability to remove nodes which are referenced to form part of a pipeline, given that the nodes are **not** in use by any other pipelines.

Whilst this behaviour may not be required for most use-cases, we've encountered ways in which a consumer of the library (Vault) would need to be able to clear up after itself to prevent memory leaks and performance issues.