### PR TITLE
Fix: go doc comments for RemovePipelineAndNodes

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -351,7 +351,7 @@ func (b *Broker) RemovePipeline(t EventType, id PipelineID) error {
 // neither the pipeline nor nodes will be deleted.
 //
 // Once we start deleting the pipeline and nodes, we will continue until completion,
-// but we'll return true with an error.
+// but we'll return true along with any errors encountered (as multierror.Error).
 func (b *Broker) RemovePipelineAndNodes(ctx context.Context, t EventType, id PipelineID) (bool, error) {
 	switch {
 	case t == "":

--- a/broker.go
+++ b/broker.go
@@ -348,10 +348,10 @@ func (b *Broker) RemovePipeline(t EventType, id PipelineID) error {
 // Any nodes that are referenced by other pipelines will not be removed.
 //
 // Failed preconditions will result in a return of false with an error and
-// neither the pipeline or nodes will be deleted.
+// neither the pipeline nor nodes will be deleted.
 //
-// Once we start deleting nodes, we will continue until completion, but we'll
-// return false with an error.
+// Once we start deleting the pipeline and nodes, we will continue until completion,
+// but we'll return true with an error.
 func (b *Broker) RemovePipelineAndNodes(ctx context.Context, t EventType, id PipelineID) (bool, error) {
 	switch {
 	case t == "":


### PR DESCRIPTION
`RemovePipelineAndNodes` go doc comment indicated that once we begin removing the pipeline and associated nodes, we will return `false` along with any error, but we only do that if we fail pre-conditions. 

Instead the comment should be updated to reflect the actual logic, which is to return `true` (that at least the pipeline was removed but node removal may have caused error).