### PR TITLE
remove 'discard' from file sink

### DIFF
--- a/file_sink.go
+++ b/file_sink.go
@@ -123,11 +123,6 @@ func (fs *FileSink) Process(ctx context.Context, e *Event) (*Event, error) {
 
 // Reopen will close, rotate and reopen the Sink's file.
 func (fs *FileSink) Reopen() error {
-	switch fs.Path {
-	case "discard":
-		return nil
-	}
-
 	fs.l.Lock()
 	defer fs.l.Unlock()
 


### PR DESCRIPTION
This looks to be a hangover from Vault related logic, `discard` is not used anywhere else in the `FileSink`.