### PR TITLE
File sink non standard cases

### DIFF
--- a/file_sink.go
+++ b/file_sink.go
@@ -123,11 +123,6 @@ func (fs *FileSink) Process(ctx context.Context, e *Event) (*Event, error) {
 
 // Reopen will close, rotate and reopen the Sink's file.
 func (fs *FileSink) Reopen() error {
-	switch fs.Path {
-	case "discard":
-		return nil
-	}
-
 	fs.l.Lock()
 	defer fs.l.Unlock()
 

--- a/file_sink_test.go
+++ b/file_sink_test.go
@@ -6,7 +6,7 @@ package eventlogger
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,12 +17,7 @@ import (
 func TestFileSink_NewDir(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	sinkDir := filepath.Join(tmpDir, "file_sink")
 
 	fs := FileSink{
@@ -34,13 +29,11 @@ func TestFileSink_NewDir(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("first")},
 		Payload:   "First entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	want := []string{"audit.log"}
-	files, _ := ioutil.ReadDir(sinkDir)
+	files, _ := os.ReadDir(sinkDir)
 	got := []string{}
 	for _, f := range files {
 		got = append(got, f.Name())
@@ -52,13 +45,7 @@ func TestFileSink_NewDir(t *testing.T) {
 
 func TestFileSink_Reopen(t *testing.T) {
 	t.Parallel()
-
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:     tmpDir,
 		FileName: "audit.log",
@@ -67,37 +54,27 @@ func TestFileSink_Reopen(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("first")},
 		Payload:   "First entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	// delete file
 	err = os.Remove(filepath.Join(tmpDir, "audit.log"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// reopen
 	err = fs.Reopen()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	event = &Event{
 		Formatted: map[string][]byte{JSONFormat: []byte("second")},
 		Payload:   "Second entry",
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Ensure process re-created the file
-	dat, err := ioutil.ReadFile(filepath.Join(tmpDir, "audit.log"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	dat, err := os.ReadFile(filepath.Join(tmpDir, "audit.log"))
+	require.NoError(t, err)
 
 	got := string(dat)
 	want := "second"
@@ -106,7 +83,7 @@ func TestFileSink_Reopen(t *testing.T) {
 	}
 
 	files := 1
-	if got, _ := ioutil.ReadDir(tmpDir); len(got) != files {
+	if got, _ := os.ReadDir(tmpDir); len(got) != files {
 		t.Errorf("Expected %d files, got %v file(s)", files, len(got))
 	}
 }
@@ -114,12 +91,7 @@ func TestFileSink_Reopen(t *testing.T) {
 func TestFileSink_TimeRotate(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:        tmpDir,
 		FileName:    "audit.log",
@@ -129,10 +101,8 @@ func TestFileSink_TimeRotate(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("first")},
 		Payload:   "First entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
 
@@ -141,12 +111,10 @@ func TestFileSink_TimeRotate(t *testing.T) {
 		Payload:   "First entry",
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	want := 2
-	if got, _ := ioutil.ReadDir(tmpDir); len(got) != want {
+	if got, _ := os.ReadDir(tmpDir); len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
 	}
 }
@@ -154,12 +122,7 @@ func TestFileSink_TimeRotate(t *testing.T) {
 func TestFileSink_TimestampOnlyOnRotate_TimeRotate(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:                  tmpDir,
 		FileName:              "audit.log",
@@ -170,10 +133,8 @@ func TestFileSink_TimestampOnlyOnRotate_TimeRotate(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("First entry")},
 		Payload:   "First entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
 
@@ -182,12 +143,10 @@ func TestFileSink_TimestampOnlyOnRotate_TimeRotate(t *testing.T) {
 		Payload:   "Last entry",
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	want := 2
-	got, _ := ioutil.ReadDir(tmpDir)
+	got, _ := os.ReadDir(tmpDir)
 	if len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
 	}
@@ -203,12 +162,7 @@ func TestFileSink_TimestampOnlyOnRotate_TimeRotate(t *testing.T) {
 func TestFileSink_ByteRotate(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:        tmpDir,
 		FileName:    "audit.log",
@@ -219,10 +173,8 @@ func TestFileSink_ByteRotate(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("entry")},
 		Payload:   "entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
 
@@ -231,12 +183,10 @@ func TestFileSink_ByteRotate(t *testing.T) {
 		Payload:   "entry",
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	want := 2
-	if got, _ := ioutil.ReadDir(tmpDir); len(got) != want {
+	if got, _ := os.ReadDir(tmpDir); len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
 	}
 }
@@ -244,12 +194,7 @@ func TestFileSink_ByteRotate(t *testing.T) {
 func TestFileSink_TimestampOnlyOnRotate_ByteRotate(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:                  tmpDir,
 		FileName:              "audit.log",
@@ -261,10 +206,8 @@ func TestFileSink_TimestampOnlyOnRotate_ByteRotate(t *testing.T) {
 		Formatted: map[string][]byte{JSONFormat: []byte("first entry")},
 		Payload:   "first entry",
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
 
@@ -273,12 +216,10 @@ func TestFileSink_TimestampOnlyOnRotate_ByteRotate(t *testing.T) {
 		Payload:   "last entry",
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	want := 2
-	got, _ := ioutil.ReadDir(tmpDir)
+	got, _ := os.ReadDir(tmpDir)
 	if len(got) != want {
 		t.Errorf("Expected %d files, got %v file(s)", want, len(got))
 	}
@@ -294,37 +235,23 @@ func TestFileSink_TimestampOnlyOnRotate_ByteRotate(t *testing.T) {
 func TestFileSink_open(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:        tmpDir,
 		FileName:    "audit.log",
 		MaxDuration: 1 * time.Second,
 	}
-	err = fs.open()
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := fs.open()
+	require.NoError(t, err)
 
-	_, err = ioutil.ReadFile(fs.f.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err = os.ReadFile(fs.f.Name())
+	require.NoError(t, err)
 }
 
 func TestFileSink_pruneFiles(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	fs := FileSink{
 		Path:        tmpDir,
 		FileName:    "audit.log",
@@ -336,29 +263,23 @@ func TestFileSink_pruneFiles(t *testing.T) {
 	event := &Event{
 		Formatted: map[string][]byte{JSONFormat: []byte("first entry")},
 	}
-	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, err := fs.Process(context.Background(), event)
+	require.NoError(t, err)
 
 	event = &Event{
 		Formatted: map[string][]byte{JSONFormat: []byte("second entry")},
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	event = &Event{
 		Formatted: map[string][]byte{JSONFormat: []byte("third entry")},
 	}
 	_, err = fs.Process(context.Background(), event)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	want := 2
-	tmpFiles, _ := ioutil.ReadDir(tmpDir)
+	tmpFiles, _ := os.ReadDir(tmpDir)
 	got := len(tmpFiles)
 	if want != got {
 		t.Errorf("Expected %d files, got %d", want, got)
@@ -367,27 +288,18 @@ func TestFileSink_pruneFiles(t *testing.T) {
 func TestFileSink_FileMode(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	configuredFileMode := os.FileMode(0640)
 	fs := FileSink{
 		Path:     tmpDir,
 		FileName: "audit.log",
 		Mode:     configuredFileMode,
 	}
-	err = fs.open()
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := fs.open()
+	require.NoError(t, err)
 
 	fileInfo, err := os.Stat(fs.f.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Ensure the file mode matches the desired mode
 	actualMode := fileInfo.Mode()
@@ -399,30 +311,22 @@ func TestFileSink_FileMode(t *testing.T) {
 func TestFileSink_DirMode(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	parentDirMode := os.FileMode(0750)
 
 	// Change mode on parent directory
-	os.Chmod(tmpDir, parentDirMode)
+	err := os.Chmod(tmpDir, parentDirMode)
+	require.NoError(t, err)
 
 	fs := FileSink{
 		Path:     tmpDir,
 		FileName: "audit.log",
 	}
 	err = fs.open()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	dirInfo, err := os.Stat(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Ensure the parent directory's permissions remain unchanged
 	actualDirMode := dirInfo.Mode()


### PR DESCRIPTION
Some parts of the `FileSink` (e.g. `Reopen`) examine the configured `Path` to see if it's in a set of special cases:

```
"/dev/stdout"
"/dev/stderr"
"/dev/devnull"
```

This PR attempts to handle cases where the special paths would mean we don't have to handle file operations in the same way, or we can return early.

Also updated tests to remove deprecated calls and squeeze out a few extra lines of code checking `if err != nil`.