### PR TITLE
Fix RegisterPipeline error after setting thresholds

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -286,7 +286,7 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 	if !exists {
 		g = &graph{}
 		b.graphs[def.EventType] = g
-	} else if b.pipelineRegistrationPolicy == DenyOverwrite {
+	} else if b.pipelineRegistrationPolicy == DenyOverwrite && g.hasRegistrations() {
 		return fmt.Errorf("pipeline ID %q is already registered, configured policy prevents overwriting", def.PipelineID)
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -46,16 +46,14 @@ type Broker struct {
 	graphs map[EventType]*graph
 	lock   sync.RWMutex
 
-	pipelineRegistrationPolicy RegistrationPolicy
-	nodeRegistrationPolicy     RegistrationPolicy
-
 	*clock
 }
 
 // nodeUsage tracks how many times a Node is referenced by registered pipelines.
 type nodeUsage struct {
-	node           Node
-	referenceCount int
+	node               Node
+	referenceCount     int
+	registrationPolicy RegistrationPolicy
 }
 
 // Option allows options to be passed as arguments.
@@ -123,22 +121,12 @@ func WithNodeRegistrationPolicy(policy RegistrationPolicy) Option {
 	}
 }
 
-// NewBroker creates a new Broker applying any supplied options.
-func NewBroker(opt ...Option) (*Broker, error) {
-	opts, err := getOpts(opt...)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create broker: %w", err)
-	}
-
+// NewBroker creates a new Broker applying any relevant supplied options.
+// Options are currently accepted, but none are applied.
+func NewBroker(_ ...Option) (*Broker, error) {
 	b := &Broker{
 		nodes:  make(map[NodeID]*nodeUsage),
 		graphs: make(map[EventType]*graph),
-	}
-	if opts.withPipelineRegistrationPolicy != "" {
-		b.pipelineRegistrationPolicy = opts.withPipelineRegistrationPolicy
-	}
-	if opts.withNodeRegistrationPolicy != "" {
-		b.nodeRegistrationPolicy = opts.withNodeRegistrationPolicy
 	}
 
 	return b, nil
@@ -230,20 +218,30 @@ type NodeID string
 // RegisterNode assigns a node ID to a node.  Node IDs should be unique. A Node
 // may be a filter, formatter or sink (see NodeType). Nodes can be shared across
 // multiple pipelines.
-func (b *Broker) RegisterNode(id NodeID, node Node) error {
+// Accepted options: WithNodeRegistrationPolicy (default: AllowOverwrite).
+func (b *Broker) RegisterNode(id NodeID, node Node, opt ...Option) error {
 	if id == "" {
 		return errors.New("unable to register node, node ID cannot be empty")
+	}
+
+	opts, err := getOpts(opt...)
+	if err != nil {
+		return fmt.Errorf("cannot register node: %w", err)
 	}
 
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	nr := &nodeUsage{node: node, referenceCount: 0}
+	nr := &nodeUsage{
+		node:               node,
+		referenceCount:     0,
+		registrationPolicy: opts.withNodeRegistrationPolicy,
+	}
 
 	// Check if this node is already registered, if so maintain reference count
 	r, exists := b.nodes[id]
 	if exists {
-		switch b.nodeRegistrationPolicy {
+		switch r.registrationPolicy {
 		case AllowOverwrite:
 			nr.referenceCount = r.referenceCount
 		case DenyOverwrite:
@@ -273,10 +271,16 @@ type Pipeline struct {
 }
 
 // RegisterPipeline adds a pipeline to the broker.
-func (b *Broker) RegisterPipeline(def Pipeline) error {
+// Accepted options: WithPipelineRegistrationPolicy (default: AllowOverwrite).
+func (b *Broker) RegisterPipeline(def Pipeline, opt ...Option) error {
 	err := def.validate()
 	if err != nil {
 		return err
+	}
+
+	opts, err := getOpts(opt...)
+	if err != nil {
+		return fmt.Errorf("cannot register pipeline: %w", err)
 	}
 
 	b.lock.Lock()
@@ -286,7 +290,19 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 	if !exists {
 		g = &graph{}
 		b.graphs[def.EventType] = g
-	} else if b.pipelineRegistrationPolicy == DenyOverwrite && g.hasRegistrations() {
+	}
+
+	// Get the configured policy
+	pol := AllowOverwrite
+	g.roots.Range(func(key PipelineID, v *pipelineRegistration) bool {
+		if key == def.PipelineID {
+			pol = v.registrationPolicy
+			return false
+		}
+		return true
+	})
+
+	if pol == DenyOverwrite {
 		return fmt.Errorf("pipeline ID %q is already registered, configured policy prevents overwriting", def.PipelineID)
 	}
 
@@ -310,8 +326,14 @@ func (b *Broker) RegisterPipeline(def Pipeline) error {
 		return err
 	}
 
+	// Create the pipeline registration using the optional policy (or default).
+	pipelineReg := &pipelineRegistration{
+		rootNode:           root,
+		registrationPolicy: opts.withPipelineRegistrationPolicy,
+	}
+
 	// Store the pipeline and then update the reference count of the nodes in that pipeline.
-	g.roots.Store(def.PipelineID, root)
+	g.roots.Store(def.PipelineID, pipelineReg)
 	for _, id := range def.NodeIDs {
 		nodeUsage, ok := b.nodes[id]
 		// We can be optimistic about this as we would have already errored above.

--- a/broker_test.go
+++ b/broker_test.go
@@ -659,9 +659,9 @@ func TestBroker_RegisterNode_AllowOverwrite_Implicit(t *testing.T) {
 // TestBroker_RegisterNode_AllowOverwrite_Explicit is used to prove that nodes can be
 // overwritten when a Broker has been explicitly configured with the AllowOverwrite policy.
 func TestBroker_RegisterNode_AllowOverwrite_Explicit(t *testing.T) {
-	b, err := NewBroker(WithNodeRegistrationPolicy(AllowOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
-	err = b.RegisterNode("n1", &JSONFormatter{})
+	err = b.RegisterNode("n1", &JSONFormatter{}, WithNodeRegistrationPolicy(AllowOverwrite))
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &FileSink{})
 	require.NoError(t, err)
@@ -670,9 +670,9 @@ func TestBroker_RegisterNode_AllowOverwrite_Explicit(t *testing.T) {
 // TestBroker_RegisterNode_DenyOverwrite is used to prove that nodes can't be
 // overwritten when a Broker has been configured with the DenyOverwrite policy.
 func TestBroker_RegisterNode_DenyOverwrite(t *testing.T) {
-	b, err := NewBroker(WithNodeRegistrationPolicy(DenyOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
-	err = b.RegisterNode("n1", &JSONFormatter{})
+	err = b.RegisterNode("n1", &JSONFormatter{}, WithNodeRegistrationPolicy(DenyOverwrite))
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &FileSink{})
 	require.Error(t, err)
@@ -713,7 +713,7 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Implicit(t *testing.T) {
 // TestBroker_RegisterPipeline_AllowOverwrite_Explicit is used to prove that pipelines can be
 // overwritten when a Broker has been explicitly configured with the AllowOverwrite policy.
 func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
-	b, err := NewBroker(WithPipelineRegistrationPolicy(AllowOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
 
 	err = b.RegisterNode("f1", &JSONFormatter{})
@@ -729,7 +729,7 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
 		PipelineID: "p1",
 		EventType:  "t",
 		NodeIDs:    []NodeID{"f1", "s1"},
-	})
+	}, WithPipelineRegistrationPolicy(AllowOverwrite))
 	require.NoError(t, err)
 
 	err = b.RegisterPipeline(Pipeline{
@@ -743,7 +743,7 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
 // TestBroker_RegisterPipeline_DenyOverwrite is used to prove that pipelines can't
 // be overwritten when a Broker has been configured with the DenyOverwrite policy.
 func TestBroker_RegisterPipeline_DenyOverwrite(t *testing.T) {
-	b, err := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
 	require.NotNil(t, b)
 
@@ -766,7 +766,7 @@ func TestBroker_RegisterPipeline_DenyOverwrite(t *testing.T) {
 		PipelineID: "p1",
 		EventType:  "t",
 		NodeIDs:    []NodeID{"f1", "s1"},
-	})
+	}, WithPipelineRegistrationPolicy(DenyOverwrite))
 	require.NoError(t, err)
 
 	err = b.RegisterPipeline(Pipeline{
@@ -780,7 +780,7 @@ func TestBroker_RegisterPipeline_DenyOverwrite(t *testing.T) {
 
 func TestBroker_RegisterPipeline_WithCloser(t *testing.T) {
 	ctx := context.Background()
-	b, err := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
 
 	mc := &mockCloserWithWrapper{n: &mockCloser{}}
@@ -806,7 +806,7 @@ func TestBroker_RegisterPipeline_WithCloser(t *testing.T) {
 
 func TestBroker_RegisterPipeline_WithCloserError(t *testing.T) {
 	ctx := context.Background()
-	b, err := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	b, err := NewBroker()
 	require.NoError(t, err)
 
 	mc := &mockCloserWithWrapper{n: &mockCloser{closeErr: errors.New("close error")}}

--- a/broker_test.go
+++ b/broker_test.go
@@ -741,9 +741,16 @@ func TestBroker_RegisterPipeline_AllowOverwrite_Explicit(t *testing.T) {
 }
 
 // TestBroker_RegisterPipeline_DenyOverwrite is used to prove that pipelines can't
-// // be overwritten when a Broker has been configured with the DenyOverwrite policy.
+// be overwritten when a Broker has been configured with the DenyOverwrite policy.
 func TestBroker_RegisterPipeline_DenyOverwrite(t *testing.T) {
 	b, err := NewBroker(WithPipelineRegistrationPolicy(DenyOverwrite))
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	// Ensure no side effects from setting thresholds before we have registered a pipeline
+	err = b.SetSuccessThreshold("t", 1)
+	require.NoError(t, err)
+	err = b.SetSuccessThresholdSinks("t", 1)
 	require.NoError(t, err)
 
 	err = b.RegisterNode("f1", &JSONFormatter{})

--- a/graph.go
+++ b/graph.go
@@ -190,3 +190,15 @@ func (g *graph) doValidate(parent, node *linkedNode) error {
 
 	return nil
 }
+
+// hasRegistrations can be used to determine if a graph has any pipelines registered.
+func (g *graph) hasRegistrations() bool {
+	var registered bool
+
+	g.roots.Range(func(_ PipelineID, root *linkedNode) bool {
+		registered = true
+		return false
+	})
+
+	return registered
+}

--- a/graph_test.go
+++ b/graph_test.go
@@ -5,7 +5,6 @@ package eventlogger
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -43,7 +42,8 @@ func TestReopen(t *testing.T) {
 	}
 
 	g := graph{}
-	g.roots.Store("id", root)
+	reg := &pipelineRegistration{rootNode: root, registrationPolicy: AllowOverwrite}
+	g.roots.Store("id", reg)
 	err = g.reopen(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +122,8 @@ func TestValidate(t *testing.T) {
 			}
 
 			g := graph{}
-			g.roots.Store("id", root)
+			reg := &pipelineRegistration{rootNode: root, registrationPolicy: AllowOverwrite}
+			g.roots.Store("id", reg)
 			err = g.validate()
 			valid := err == nil
 			if valid != tc.valid {
@@ -225,7 +226,8 @@ func TestSendResult(t *testing.T) {
 			}
 
 			g := graph{successThreshold: tc.threshold, successThresholdSinks: tc.thresholdSinks}
-			g.roots.Store("id", root)
+			reg := &pipelineRegistration{rootNode: root, registrationPolicy: AllowOverwrite}
+			g.roots.Store("id", reg)
 
 			err = g.validate()
 			if err != nil {
@@ -354,7 +356,8 @@ func TestSendBlocking(t *testing.T) {
 			}
 
 			g := graph{successThreshold: tc.threshold}
-			g.roots.Store("id", root)
+			reg := &pipelineRegistration{rootNode: root, registrationPolicy: AllowOverwrite}
+			g.roots.Store("id", reg)
 
 			err = g.validate()
 			if err != nil {
@@ -385,22 +388,4 @@ func TestSendBlocking(t *testing.T) {
 	// Sleep long enough that the 1s sleep in fileSinkDelayed completes, to
 	// satisfy the go leak detector in TestMain.
 	time.Sleep(700 * time.Millisecond)
-}
-
-// TestGraph_HasRegistrations ensures that hasRegistrations performs as expected.
-// If anything has been stored against the roots then we should expect true,
-// otherwise false.
-func TestGraph_HasRegistrations(t *testing.T) {
-	g := graph{}
-
-	// No registrations to begin with.
-	require.False(t, g.hasRegistrations())
-
-	// Store something and ensure we have registrations.
-	g.roots.Store("abc", nil)
-	require.True(t, g.hasRegistrations())
-
-	// Delete the stored entry and ensure we have no registrations.
-	g.roots.Delete("abc")
-	require.False(t, g.hasRegistrations())
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -5,6 +5,7 @@ package eventlogger
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -384,4 +385,22 @@ func TestSendBlocking(t *testing.T) {
 	// Sleep long enough that the 1s sleep in fileSinkDelayed completes, to
 	// satisfy the go leak detector in TestMain.
 	time.Sleep(700 * time.Millisecond)
+}
+
+// TestGraph_HasRegistrations ensures that hasRegistrations performs as expected.
+// If anything has been stored against the roots then we should expect true,
+// otherwise false.
+func TestGraph_HasRegistrations(t *testing.T) {
+	g := graph{}
+
+	// No registrations to begin with.
+	require.False(t, g.hasRegistrations())
+
+	// Store something and ensure we have registrations.
+	g.roots.Store("abc", nil)
+	require.True(t, g.hasRegistrations())
+
+	// Delete the stored entry and ensure we have no registrations.
+	g.roots.Delete("abc")
+	require.False(t, g.hasRegistrations())
 }

--- a/graphmap.go
+++ b/graphmap.go
@@ -15,15 +15,22 @@ type graphMap struct {
 	m sync.Map
 }
 
+// pipelineRegistration represents both linked nodes and the registration policy
+// for the pipeline.
+type pipelineRegistration struct {
+	rootNode           *linkedNode
+	registrationPolicy RegistrationPolicy
+}
+
 // Range calls sync.Map.Range
-func (g *graphMap) Range(f func(key PipelineID, value *linkedNode) bool) {
+func (g *graphMap) Range(f func(key PipelineID, value *pipelineRegistration) bool) {
 	g.m.Range(func(key, value interface{}) bool {
-		return f(key.(PipelineID), value.(*linkedNode))
+		return f(key.(PipelineID), value.(*pipelineRegistration))
 	})
 }
 
 // Store calls sync.Map.Store
-func (g *graphMap) Store(id PipelineID, root *linkedNode) {
+func (g *graphMap) Store(id PipelineID, root *pipelineRegistration) {
 	g.m.Store(id, root)
 }
 
@@ -34,16 +41,17 @@ func (g *graphMap) Delete(id PipelineID) {
 
 // Nodes returns all the nodes referenced by the specified Pipeline
 func (g *graphMap) Nodes(id PipelineID) ([]NodeID, error) {
-	root, ok := g.m.Load(id)
+	v, ok := g.m.Load(id)
 	if !ok {
 		return nil, fmt.Errorf("unable to load root node from underlying data store")
 	}
 
-	ln, ok := root.(*linkedNode)
+	pr, ok := v.(*pipelineRegistration)
 	if !ok {
-		return nil, fmt.Errorf("unable to retrieve linked nodes from underlying data store")
+		return nil, fmt.Errorf("unable to retrieve pipeline registration (linked nodes and policy) from underlying data store")
 	}
-	nodes := ln.flatten()
+
+	nodes := pr.rootNode.flatten()
 	result := make([]NodeID, len(nodes))
 	i := 0
 	for k := range nodes {

--- a/graphmap_test.go
+++ b/graphmap_test.go
@@ -32,7 +32,8 @@ func TestNodes_ListNodes_RegisteredPipeline(t *testing.T) {
 	linkedNodes, err := linkNodes(nodes, ids)
 	require.NoError(t, err)
 
-	g.Store(PipelineID("1"), linkedNodes)
+	reg := &pipelineRegistration{rootNode: linkedNodes, registrationPolicy: AllowOverwrite}
+	g.Store(PipelineID("1"), reg)
 	nodeIDs, err := g.Nodes(PipelineID("1"))
 	require.NoError(t, err)
 	require.NotNil(t, nodeIDs)


### PR DESCRIPTION
This PR fixes a bug which incorrectly applied policies to all pipelines under a given `EventType` rather than a specific pipeline.

This isn't the behavior that was intended.