### PR TITLE
Max/existence check

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -475,8 +475,8 @@ func (b *Broker) SetSuccessThresholdSinks(t EventType, successThresholdSinks int
 	return nil
 }
 
-// IsPipelineRegistered returns whether a pipeline for a given event type is already registered or not.
-func (b *Broker) IsPipelineRegistered(e EventType) bool {
+// IsAnyPipelineRegistered returns whether a pipeline for a given event type is already registered or not.
+func (b *Broker) IsAnyPipelineRegistered(e EventType) bool {
 	g, found := b.graphs[e]
 	if !found {
 		return false

--- a/broker.go
+++ b/broker.go
@@ -475,6 +475,21 @@ func (b *Broker) SetSuccessThresholdSinks(t EventType, successThresholdSinks int
 	return nil
 }
 
+// IsPipelineRegistered returns whether a pipeline for a given event type is already registered or not.
+func (b *Broker) IsPipelineRegistered(e EventType) bool {
+	g, found := b.graphs[e]
+	if !found {
+		return false
+	}
+
+	found = false
+	g.roots.Range(func(_ PipelineID, pipeline *registeredPipeline) bool {
+		found = true
+		return false
+	})
+	return found
+}
+
 // validate ensures that the Pipeline has the required configuration to allow
 // registration, removal or usage, without issue.
 func (p Pipeline) validate() error {

--- a/broker_test.go
+++ b/broker_test.go
@@ -888,3 +888,38 @@ func TestBroker_RegisterPipeline_WithCloserError(t *testing.T) {
 	assert.Contains(t, err.Error(), "close error")
 	assert.False(t, mc.n.closed)
 }
+
+func TestBroker_IsPipelineRegistered(t *testing.T) {
+	b, err := NewBroker()
+	require.NoError(t, err)
+
+	err = b.RegisterNode("f1", &JSONFormatter{})
+	require.NoError(t, err)
+
+	err = b.RegisterNode("s1", &FileSink{})
+	require.NoError(t, err)
+
+	err = b.RegisterPipeline(Pipeline{
+		PipelineID: "p1",
+		EventType:  "t",
+		NodeIDs:    []NodeID{"f1", "s1"},
+	})
+	require.NoError(t, err)
+
+	require.True(t, b.IsPipelineRegistered("t"))
+	require.False(t, b.IsPipelineRegistered("i-do-not-exist"))
+}
+
+func TestBroker_IsPipelineRegistered_WithFailedRegistration(t *testing.T) {
+	b, err := NewBroker()
+	require.NoError(t, err)
+
+	err = b.RegisterPipeline(Pipeline{
+		PipelineID: "p1",
+		EventType:  "t",
+		NodeIDs:    []NodeID{},
+	})
+	require.Error(t, err)
+
+	require.False(t, b.IsPipelineRegistered("t"))
+}

--- a/broker_test.go
+++ b/broker_test.go
@@ -889,7 +889,7 @@ func TestBroker_RegisterPipeline_WithCloserError(t *testing.T) {
 	assert.False(t, mc.n.closed)
 }
 
-func TestBroker_IsPipelineRegistered(t *testing.T) {
+func TestBroker_IsAnyPipelineRegistered(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 
@@ -906,11 +906,11 @@ func TestBroker_IsPipelineRegistered(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.True(t, b.IsPipelineRegistered("t"))
-	require.False(t, b.IsPipelineRegistered("i-do-not-exist"))
+	require.True(t, b.IsAnyPipelineRegistered("t"))
+	require.False(t, b.IsAnyPipelineRegistered("i-do-not-exist"))
 }
 
-func TestBroker_IsPipelineRegistered_WithFailedRegistration(t *testing.T) {
+func TestBroker_IsAnyPipelineRegistered_WithFailedRegistration(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 
@@ -921,5 +921,5 @@ func TestBroker_IsPipelineRegistered_WithFailedRegistration(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	require.False(t, b.IsPipelineRegistered("t"))
+	require.False(t, b.IsAnyPipelineRegistered("t"))
 }


### PR DESCRIPTION
Added a small method to check if an event type exists so upstream callers can lazily register pipelines by first checking if an event type is supported before sending an event of that type.