### PR TITLE
broker: add DeregisterNode function

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -268,7 +268,6 @@ func (b *Broker) RegisterNode(id NodeID, node Node, opt ...Option) error {
 // DeregisterNode will remove a node from the broker, if it is not currently  in use
 // This is useful if RegisterNode was used successfully prior to a failed RegisterPipeline call
 // referencing those nodes
-// Accepted options: withDecrementNodeReferenceIfStillUsed.
 func (b *Broker) DeregisterNode(ctx context.Context, id NodeID, opt ...Option) error {
 	if id == "" {
 		return fmt.Errorf("unable to deregister node, node ID cannot be empty: %w", ErrInvalidParameter)
@@ -287,6 +286,8 @@ func (b *Broker) DeregisterNode(ctx context.Context, id NodeID, opt ...Option) e
 		return fmt.Errorf("%w: %q", ErrNodeNotFound, id)
 	}
 
+	// if withDecrementNodeReferenceIfStillUsed is passed, then it's fine to decrement the count for this node
+	// instead of failing
 	if nodeUsage.referenceCount > 0 && !opts.withDecrementNodeReferenceIfStillUsed {
 		return fmt.Errorf("cannot deregister node, as it is still in use by 1 or more pipelines: %q", id)
 	}

--- a/broker.go
+++ b/broker.go
@@ -123,9 +123,9 @@ func WithNodeRegistrationPolicy(policy RegistrationPolicy) Option {
 	}
 }
 
-// WithDecrementNodeReferenceIfStillUsed configures the option that determines whether deregistering
+// withDecrementNodeReferenceIfStillUsed configures the option that determines whether deregistering
 // a node is used by more than one pipeline should result in decrementing its usage count
-func WithDecrementNodeReferenceIfStillUsed(b bool) Option {
+func withDecrementNodeReferenceIfStillUsed(b bool) Option {
 	return func(o *options) error {
 		o.withDecrementNodeReferenceIfStillUsed = b
 		return nil
@@ -268,7 +268,7 @@ func (b *Broker) RegisterNode(id NodeID, node Node, opt ...Option) error {
 // DeregisterNode will remove a node from the broker, if it is not currently  in use
 // This is useful if RegisterNode was used successfully prior to a failed RegisterPipeline call
 // referencing those nodes
-// Accepted options: WithDecrementNodeReferenceIfStillUsed.
+// Accepted options: withDecrementNodeReferenceIfStillUsed.
 func (b *Broker) DeregisterNode(ctx context.Context, id NodeID, opt ...Option) error {
 	if id == "" {
 		return fmt.Errorf("unable to deregister node, node ID cannot be empty: %w", ErrInvalidParameter)
@@ -453,7 +453,7 @@ func (b *Broker) RemovePipelineAndNodes(ctx context.Context, t EventType, id Pip
 	var nodeErr error
 
 	for _, nodeID := range nodes {
-		err = b.DeregisterNode(ctx, nodeID, WithDecrementNodeReferenceIfStillUsed(true))
+		err = b.DeregisterNode(ctx, nodeID, withDecrementNodeReferenceIfStillUsed(true))
 		if err != nil {
 			nodeErr = multierror.Append(nodeErr, err)
 		}

--- a/broker.go
+++ b/broker.go
@@ -255,7 +255,7 @@ func (b *Broker) RegisterNode(id NodeID, node Node, opt ...Option) error {
 }
 
 // DeregisterNode will remove a node from the broker, if it is not currently  in use
-// This is useful if RegisterNode was used succesfully prior to a failed RegisterPipeline call
+// This is useful if RegisterNode was used successfully prior to a failed RegisterPipeline call
 // referencing those nodes
 func (b *Broker) DeregisterNode(ctx context.Context, id NodeID) error {
 	if id == "" {

--- a/broker_test.go
+++ b/broker_test.go
@@ -733,14 +733,14 @@ func TestDeregisterNode_StillReferenced(t *testing.T) {
 }
 
 // TestDeregisterNode_StillReferencedDecrement ensures we can decrement the reference to a Node that is still referenced
-// by a pipeline by using the option WithDecrementNodeReferenceIfStillUsed
+// by a pipeline by using the option withDecrementNodeReferenceIfStillUsed
 func TestDeregisterNode_StillReferencedDecrement(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	b.nodes["n1"].referenceCount = 2
-	err = b.DeregisterNode(context.Background(), "n1", WithDecrementNodeReferenceIfStillUsed(true))
+	err = b.DeregisterNode(context.Background(), "n1", withDecrementNodeReferenceIfStillUsed(true))
 	require.NoError(t, err)
 	require.Equal(t, 1, b.nodes["n1"].referenceCount)
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -692,55 +692,55 @@ func TestBroker_RegisterNode_AllowThenDenyOverwrite(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestDeregisterNode ensures we cannot deregister a Node with an empty ID.
-func TestDeregisterNode(t *testing.T) {
+// TestRemoveNode ensures we cannot remove a Node with an empty ID.
+func TestRemoveNode(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
-	err = b.DeregisterNode(context.Background(), "n1")
+	err = b.RemoveNode(context.Background(), "n1")
 	require.NoError(t, err)
 }
 
-// TestDeregisterNode_NoID ensures we cannot deregister a Node with an empty ID.
-func TestDeregisterNode_NoID(t *testing.T) {
+// TestRemoveNode_NoID ensures we cannot remove a Node with an empty ID.
+func TestRemoveNode_NoID(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
-	err = b.DeregisterNode(context.Background(), "")
+	err = b.RemoveNode(context.Background(), "")
 	require.Error(t, err)
-	require.EqualError(t, err, "unable to deregister node, node ID cannot be empty: invalid parameter")
+	require.EqualError(t, err, "unable to remove node, node ID cannot be empty: invalid parameter")
 }
 
-// TestDeregisterNode_NotFound ensures we cannot deregister a Node that has not been registered
-func TestDeregisterNode_NotFound(t *testing.T) {
+// TestRemoveNode_NotFound ensures we cannot remove a Node that has not been registered
+func TestRemoveNode_NotFound(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
-	err = b.DeregisterNode(context.Background(), "n1")
+	err = b.RemoveNode(context.Background(), "n1")
 	require.Error(t, err)
 	require.EqualError(t, err, "node not found: \"n1\"")
 }
 
-// TestDeregisterNode_StillReferenced ensures we cannot deregister a Node that is still referenced by a pipeline
-func TestDeregisterNode_StillReferenced(t *testing.T) {
+// TestRemoveNode_StillReferenced ensures we cannot remote a Node that is still referenced by a pipeline
+func TestRemoveNode_StillReferenced(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	b.nodes["n1"].referenceCount = 2
-	err = b.DeregisterNode(context.Background(), "n1")
+	err = b.RemoveNode(context.Background(), "n1")
 	require.Error(t, err)
-	require.EqualError(t, err, "cannot deregister node, as it is still in use by 1 or more pipelines: \"n1\"")
+	require.EqualError(t, err, "cannot remove node, as it is still in use by 1 or more pipelines: \"n1\"")
 }
 
-// TestDeregisterNode_StillReferencedDecrement ensures we can decrement the reference to a Node that is still referenced
-// by a pipeline by using the option withDecrementNodeReferenceIfStillUsed
-func TestDeregisterNode_StillReferencedDecrement(t *testing.T) {
+// TestDeregisterNode_Force ensures we can decrement the reference to a Node that is still referenced
+// by a pipeline by using the force option
+func TestRemoveNode_StillReferencedDecrement(t *testing.T) {
 	b, err := NewBroker()
 	require.NoError(t, err)
 	err = b.RegisterNode("n1", &JSONFormatter{})
 	require.NoError(t, err)
 	b.nodes["n1"].referenceCount = 2
-	err = b.DeregisterNode(context.Background(), "n1", withDecrementNodeReferenceIfStillUsed(true))
+	err = b.removeNode(context.Background(), "n1", true)
 	require.NoError(t, err)
 	require.Equal(t, 1, b.nodes["n1"].referenceCount)
 }

--- a/error.go
+++ b/error.go
@@ -7,4 +7,5 @@ import "errors"
 
 var (
 	ErrInvalidParameter = errors.New("invalid parameter")
+	ErrNodeNotFound     = errors.New("node not found")
 )


### PR DESCRIPTION
Addition of a DeregisterNode function, which will remove a node from the broker, if it is not currently  in use
This is useful if RegisterNode was used successfully prior to a failed RegisterPipeline call referencing those nodes