### PR TITLE
receivers to allow access to a Status' complete and complete-sink IDs

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -161,6 +161,16 @@ type Status struct {
 	Warnings []error
 }
 
+// Complete returns the IDs of 'filter' and 'sink' type nodes that successfully processed the Event.
+func (s Status) Complete() []NodeID {
+	return s.complete
+}
+
+// CompleteSinks returns the IDs of 'sink' type nodes that successfully processed the Event.
+func (s Status) CompleteSinks() []NodeID {
+	return s.completeSinks
+}
+
 func (s Status) getError(threshold, thresholdSinks int) error {
 	switch {
 	case len(s.complete) < threshold:


### PR DESCRIPTION
Allowing accessors for these un-exported fields allows consuming code to more easily correlate successful node processing.

This way we don't cause issues with anyone that was relying on `Status` only exporting the `Warnings` field. 