### PR TITLE
Broker `Status`: Updated go docs for `Complete()` and `CompleteSinks()`

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -153,20 +153,24 @@ func (b *Broker) StopTimeAt(now time.Time) {
 
 // Status describes the result of a Send.
 type Status struct {
-	// complete lists the IDs of 'filter' and 'sink' type nodes that successfully processed the Event.
+	// complete lists the IDs of 'filter' and 'sink' type nodes that successfully
+	// processed the Event, leading to completion of a particular Pipeline.
 	complete []NodeID
-	// complete lists the IDs of 'sink' type nodes that successfully processed the Event.
+	// complete lists the IDs of 'sink' type nodes that successfully processed
+	// the Event, leading to completion of a particular Pipeline.
 	completeSinks []NodeID
 	// Warnings lists any non-fatal errors that occurred while sending an Event.
 	Warnings []error
 }
 
-// Complete returns the IDs of 'filter' and 'sink' type nodes that successfully processed the Event.
+// Complete returns the IDs of 'filter' and 'sink' type nodes that successfully
+// processed the Event, leading to completion of a particular Pipeline.
 func (s Status) Complete() []NodeID {
 	return s.complete
 }
 
-// CompleteSinks returns the IDs of 'sink' type nodes that successfully processed the Event.
+// CompleteSinks returns the IDs of 'sink' type nodes that successfully processed
+// the Event, leading to completion of a particular Pipeline.
 func (s Status) CompleteSinks() []NodeID {
 	return s.completeSinks
 }

--- a/broker.go
+++ b/broker.go
@@ -156,7 +156,7 @@ type Status struct {
 	// complete lists the IDs of 'filter' and 'sink' type nodes that successfully
 	// processed the Event, resulting in immediate completion of a particular Pipeline.
 	complete []NodeID
-	// complete lists the IDs of 'sink' type nodes that successfully processed
+	// completeSinks lists the IDs of 'sink' type nodes that successfully processed
 	// the Event, resulting in immediate completion of a particular Pipeline.
 	completeSinks []NodeID
 	// Warnings lists any non-fatal errors that occurred while sending an Event.

--- a/broker.go
+++ b/broker.go
@@ -154,23 +154,23 @@ func (b *Broker) StopTimeAt(now time.Time) {
 // Status describes the result of a Send.
 type Status struct {
 	// complete lists the IDs of 'filter' and 'sink' type nodes that successfully
-	// processed the Event, leading to completion of a particular Pipeline.
+	// processed the Event, resulting in immediate completion of a particular Pipeline.
 	complete []NodeID
 	// complete lists the IDs of 'sink' type nodes that successfully processed
-	// the Event, leading to completion of a particular Pipeline.
+	// the Event, resulting in immediate completion of a particular Pipeline.
 	completeSinks []NodeID
 	// Warnings lists any non-fatal errors that occurred while sending an Event.
 	Warnings []error
 }
 
 // Complete returns the IDs of 'filter' and 'sink' type nodes that successfully
-// processed the Event, leading to completion of a particular Pipeline.
+// processed the Event, resulting in immediate completion of a particular Pipeline.
 func (s Status) Complete() []NodeID {
 	return s.complete
 }
 
 // CompleteSinks returns the IDs of 'sink' type nodes that successfully processed
-// the Event, leading to completion of a particular Pipeline.
+// the Event, resulting in immediate completion of a particular Pipeline.
 func (s Status) CompleteSinks() []NodeID {
 	return s.completeSinks
 }


### PR DESCRIPTION
Small go doc update to make it clearer to the consumer that only nodes which have effectively 'terminated' the pipeline successfully will appear in the return value of `Complete()` and `CompleteSinks()` (and their underlying fields `complete` and `completeSinks`.