### PR TITLE
Draft: Allow invoked pipelines to complete, mitigate blocking on status channel

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -599,3 +599,22 @@ func (p Pipeline) validate() error {
 
 	return err
 }
+
+// SetRequireAllPipelinesComplete is used to set a 'per EventType' setting which
+// specifies whether every pipeline invoked for this EventType should complete
+// before we will allow execution to return to the caller.
+// Configuring an EventType's Pipelines to all require completion means that even
+// cancelling the context alone will not immediately return from a Broker.Send
+// in the return to calling code.
+func (b *Broker) SetRequireAllPipelinesComplete(eventType EventType, requireAll bool) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	g, exists := b.graphs[eventType]
+	if !exists {
+		g = &graph{}
+		b.graphs[eventType] = g
+	}
+
+	g.requireAllPipelinesComplete = requireAll
+}

--- a/broker_test.go
+++ b/broker_test.go
@@ -1187,3 +1187,23 @@ func TestBroker_Status_CompleteSinks(t *testing.T) {
 		})
 	}
 }
+
+func TestBroker_SetRequireAllPipelinesComplete(t *testing.T) {
+	t.Parallel()
+
+	// Create a broker
+	broker, err := NewBroker()
+	require.NoError(t, err)
+
+	// Turn 'on'
+	broker.SetRequireAllPipelinesComplete("foo", true)
+
+	// Get the pointer to the graph for further inspection.
+	g := broker.graphs["foo"]
+	require.NotNil(t, g)
+	require.True(t, g.requireAllPipelinesComplete)
+
+	// Turn 'off' and check setting.
+	broker.SetRequireAllPipelinesComplete("foo", false)
+	require.False(t, g.requireAllPipelinesComplete)
+}

--- a/graphmap.go
+++ b/graphmap.go
@@ -13,6 +13,13 @@ import (
 // graphMap implements a type-safe synchronized map[PipelineID]*linkedNode
 type graphMap struct {
 	m sync.Map
+
+	// numRoots attempts to track the number of root nodes that are registered in
+	// the associate map of pipelines. This can be useful for the graph to decide
+	// how large a channel should be for receiving Status from nodes as they process.
+	// Later it may require a lock/mutex in order to synchronize the Store and Delete
+	// operations on the map, but for now this should be accurate enough.
+	numRoots int
 }
 
 // registeredPipeline represents both linked nodes and the registration policy
@@ -31,12 +38,22 @@ func (g *graphMap) Range(f func(key PipelineID, value *registeredPipeline) bool)
 
 // Store calls sync.Map.Store
 func (g *graphMap) Store(id PipelineID, root *registeredPipeline) {
+	// Store the root node and increment how many we have.
+	// NOTE: These two actions might not be atomic, so potentially something could
+	// start to range over the map before we've made the change to the total number
+	// of roots.
 	g.m.Store(id, root)
+	g.numRoots++
 }
 
 // Delete calls sync.Map.Delete
 func (g *graphMap) Delete(id PipelineID) {
+	// Delete the nodes for the pipeline, and decrement how many root nodes we have.
+	// NOTE: These two actions might not be atomic, so potentially something could
+	// start to range over the map before we've made the change to the total number
+	// of roots.
 	g.m.Delete(id)
+	g.numRoots--
 }
 
 // Nodes returns all the nodes referenced by the specified Pipeline
@@ -58,5 +75,6 @@ func (g *graphMap) Nodes(id PipelineID) ([]NodeID, error) {
 		result[i] = k
 		i++
 	}
+
 	return result, nil
 }

--- a/graphmap_test.go
+++ b/graphmap_test.go
@@ -41,3 +41,91 @@ func TestNodes_ListNodes_RegisteredPipeline(t *testing.T) {
 	require.Contains(t, nodeIDs, NodeID("b"))
 	require.Contains(t, nodeIDs, NodeID("c"))
 }
+
+func TestGraphMap_Store(t *testing.T) {
+	t.Parallel()
+
+	g := &graphMap{}
+	findPipeline := pipelineFinder(g)
+
+	// Set up pipeline for storing.
+	id := PipelineID("foo")
+	p := &registeredPipeline{
+		registrationPolicy: "bar",
+	}
+
+	// Sanity check we have nothing to start with.
+	require.Equal(t, 0, g.numRoots)
+	v := findPipeline(id)
+	require.Nil(t, v)
+
+	// Store the pipeline then check we stored it and incremented the counter.
+	g.Store(id, p)
+	require.Equal(t, 1, g.numRoots)
+	v = findPipeline(id)
+	require.NotNil(t, v)
+	require.Equal(t, RegistrationPolicy("bar"), v.registrationPolicy)
+
+	// Store it again, and check it's still there but the counter hasn't changed
+	// since it's per distinct ID.
+	p.registrationPolicy = "baz"
+	g.Store(id, p)
+	require.Equal(t, 1, g.numRoots)
+	v = findPipeline(id)
+	require.NotNil(t, v)
+	require.Equal(t, RegistrationPolicy("baz"), v.registrationPolicy)
+}
+
+func TestGraphMap_Delete(t *testing.T) {
+	t.Parallel()
+
+	g := &graphMap{}
+	findPipeline := pipelineFinder(g)
+
+	// Set up pipeline for storing.
+	id := PipelineID("foo")
+	p := &registeredPipeline{
+		registrationPolicy: "bar",
+	}
+
+	// Sanity check we have nothing to start with.
+	require.Equal(t, 0, g.numRoots)
+	v := findPipeline(id)
+	require.Nil(t, v)
+
+	// Store the pipeline then check we stored it and incremented the counter.
+	g.Store(id, p)
+	require.Equal(t, 1, g.numRoots)
+	v = findPipeline(id)
+	require.NotNil(t, v)
+	require.Equal(t, RegistrationPolicy("bar"), v.registrationPolicy)
+
+	// Now delete the pipeline and check it's gone and the counter went down.
+	g.Delete(id)
+	require.Equal(t, 0, g.numRoots)
+	v = findPipeline(id)
+	require.Nil(t, v)
+
+	// Delete again and make sure nothing funky happens.
+	g.Delete(id)
+	require.Equal(t, 0, g.numRoots)
+	v = findPipeline(id)
+	require.Nil(t, v)
+}
+
+// pipelineFinder returns a func that can be used to find a pipeline in a graphMap.
+func pipelineFinder(g *graphMap) func(id PipelineID) *registeredPipeline {
+	return func(id PipelineID) *registeredPipeline {
+		var res *registeredPipeline
+
+		g.Range(func(key PipelineID, rp *registeredPipeline) bool {
+			if key == id {
+				res = rp
+				return false
+			}
+			return true
+		})
+
+		return res
+	}
+}


### PR DESCRIPTION
**DRAFT: IN PROGRESS**

This PR is intended to be used initially for discussion of potential changes/improvements to `go-eventlogger`.

Perceived issues:

* `graph.process` The `Status` channel is changed from unbuffered (default size) to buffered, the size will be the estimated number of nodes within all pipelines (number of root nodes `* 3`). This is to prevent occurrence of sending messages to a blocked channel is no longer being received on
* `graph.process` While ranging over the root nodes, do not invoke roots when we know the context is already `Done`
* `graph.doProcess` parameter tweaked so the channel supplied can only be used for sending
* `broker.SetRequireAllPipelinesComplete` Added broker-level setting (per event type) to decide whether `process` should allow all invoked pipelines to complete and return their status before gathering/fanning-in 

