### PR TITLE
broker: `Send` return error can be context aware.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
-        go-version: 1.20
+        go-version: '1.20'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Set up Go
-      uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
       with:
         go-version: 1.20
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
-        go-version: 1.16
+        go-version: 1.20
 
     - name: Build
       run: go build -v ./...

--- a/broker.go
+++ b/broker.go
@@ -175,15 +175,18 @@ func (s Status) CompleteSinks() []NodeID {
 	return s.completeSinks
 }
 
-func (s Status) getError(threshold, thresholdSinks int) error {
+func (s Status) getError(ctxErr error, threshold, thresholdSinks int) error {
+	var err error
 	switch {
 	case len(s.complete) < threshold:
-		return fmt.Errorf("event not processed by enough 'filter' and 'sink' nodes")
+		err = fmt.Errorf("event not processed by enough 'filter' and 'sink' nodes")
 	case len(s.completeSinks) < thresholdSinks:
-		return fmt.Errorf("event not processed by enough 'sink' nodes")
+		err = fmt.Errorf("event not processed by enough 'sink' nodes")
 	default:
 		return nil
 	}
+
+	return errors.Join(err, ctxErr)
 }
 
 // Send writes an event of type t to all registered pipelines concurrently and

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/eventlogger
 
-go 1.16
+go 1.20
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,26 @@ module github.com/hashicorp/eventlogger
 go 1.20
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-test/deep v1.0.4
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.1
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/kr/pretty v0.2.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/goleak v1.0.0
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	mvdan.cc/gofumpt v0.1.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/mod v0.4.0 // indirect
+	golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/graph.go
+++ b/graph.go
@@ -59,7 +59,7 @@ func (g *graph) process(ctx context.Context, e *Event) (Status, error) {
 			}
 		}
 	}
-	return status, status.getError(g.successThreshold, g.successThresholdSinks)
+	return status, status.getError(ctx.Err(), g.successThreshold, g.successThresholdSinks)
 }
 
 // Recursively process every node in the graph.


### PR DESCRIPTION
Improvement: 

When the `Broker` performs a `Send` and decides what the returned error should look like, we can include the state of the context (`context.Err()`) at that moment and allow `getError` to decide if context information needs to be included in the return.

This allows callers to understand why the `Broker` may have ended processing early.

Change:

This PR also updates the required version of Go from `1.16` to `1.20` as we now use [`errors.Join`](https://pkg.go.dev/errors#Join) added in `1.20`. Updates are made to the `go.mod` and CI files and a `go mod tidy` performed.

It also updates the GHA for checkout and go-version.